### PR TITLE
Safe and handy resources interface for library user - overloaded constructors

### DIFF
--- a/kentik_api_library/examples/labels_example.py
+++ b/kentik_api_library/examples/labels_example.py
@@ -9,7 +9,6 @@ import logging
 from typing import Tuple
 from kentik_api import KentikAPI, DeviceLabel
 
-
 logging.basicConfig(level=logging.INFO)
 
 
@@ -44,7 +43,7 @@ def run_crud() -> None:
     client = KentikAPI(email, token)
 
     print("### CREATE")
-    label = DeviceLabel("apitest-label-1", "#0000FF")
+    label = DeviceLabel(name="apitest-label-1", color="#0000FF")
     created = client.device_labels.create(label)
     print(created.__dict__)
     print()

--- a/kentik_api_library/kentik_api/api_resources/device_labels_api.py
+++ b/kentik_api_library/kentik_api/api_resources/device_labels_api.py
@@ -21,7 +21,6 @@ class DeviceLabelsAPI(BaseAPI):
         return labels_payload.GetResponse.from_json(response.text).to_device_label()
 
     def create(self, device_label: DeviceLabel) -> DeviceLabel:
-        assert device_label.color is not None
         apicall = device_labels.create_device_label()
         payload = labels_payload.CreateRequest(device_label.name, device_label.color)
         response = self.send(apicall, payload)

--- a/kentik_api_library/kentik_api/public/__init__.py
+++ b/kentik_api_library/kentik_api/public/__init__.py
@@ -1,3 +1,4 @@
+from .types import ID
 from .device_label import DeviceLabel
 from .site import Site
 from .user import User

--- a/kentik_api_library/kentik_api/public/defaults.py
+++ b/kentik_api_library/kentik_api/public/defaults.py
@@ -1,0 +1,4 @@
+from kentik_api.public.types import ID
+
+DEFAULT_ID = ID(-1)
+DEFAULT_DATE = "1970-01-01T00:00:00.000Z"

--- a/kentik_api_library/kentik_api/public/device_label.py
+++ b/kentik_api_library/kentik_api/public/device_label.py
@@ -36,7 +36,7 @@ class DeviceLabel:
         color: str,
         devices: List[DeviceItem],
         id: ID,
-        user_id: ID,
+        user_id: Optional[ID],
         company_id: ID,
         created_date: str,
         updated_date: str,
@@ -58,7 +58,7 @@ class DeviceLabel:
         self._id = kwargs.get("id", DEFAULT_ID)
         self._user_id = kwargs.get("user_id", DEFAULT_ID)
         self._company_id = kwargs.get("company_id", DEFAULT_ID)
-        self._devices: List[DeviceItem] = kwargs.get("devices", [])
+        self._devices = kwargs.get("devices", [])
         self._created_date = kwargs.get("created_date", DEFAULT_DATE)
         self._updated_date = kwargs.get("updated_date", DEFAULT_DATE)
 
@@ -69,7 +69,7 @@ class DeviceLabel:
         return self._id
 
     @property
-    def user_id(self) -> ID:
+    def user_id(self) -> Optional[ID]:
         return self._user_id
 
     @property

--- a/kentik_api_library/kentik_api/public/device_label.py
+++ b/kentik_api_library/kentik_api/public/device_label.py
@@ -1,12 +1,12 @@
-from typing import List, Any, Optional
+from typing import List, Optional, overload
 from dataclasses import dataclass
 
 from kentik_api.public.types import ID
+from kentik_api.public.defaults import DEFAULT_ID, DEFAULT_DATE
 
 
-@dataclass
+@dataclass(frozen=True)
 class DeviceItem:
-
     id: ID
     device_name: str
     device_subtype: str
@@ -18,42 +18,62 @@ class DeviceItem:
 
 class DeviceLabel:
     # pylint: disable=too-many-arguments
+
+    @overload
+    def __init__(self, name: str, color: str) -> None:
+        """ Create """
+        ...
+
+    @overload
+    def __init__(self, id: ID, name: str, color: str) -> None:
+        """ Update """
+        ...
+
+    @overload
     def __init__(
         self,
         name: str,
-        color: Optional[str] = None,
-        id: Optional[ID] = None,
-        user_id: Optional[ID] = None,
-        company_id: Optional[ID] = None,
-        devices: Optional[List[DeviceItem]] = None,
-        created_date: Optional[str] = None,
-        updated_date: Optional[str] = None,
+        color: str,
+        devices: List[DeviceItem],
+        id: ID,
+        user_id: ID,
+        company_id: ID,
+        created_date: str,
+        updated_date: str,
     ) -> None:
+        """ Library-internal use """
+        ...
+
+    def __init__(self, *args, **kwargs) -> None:
+        """ This constructor covers all the overloads """
+
+        if len(args) > 0:
+            raise RuntimeError(f"DeviceLabel() supports only named argumets, got positional: {args}")
+
         # read-write
-        self.name = name
-        self.color = color
+        self.name = kwargs["name"]
+        self.color = kwargs["color"]
 
         # read-only
-        self._id = id
-        self._user_id = user_id
-        self._company_id = company_id
-        self._devices = devices
-        self._created_date = created_date
-        self._updated_date = updated_date
+        self._id = kwargs.get("id", DEFAULT_ID)
+        self._user_id = kwargs.get("user_id", DEFAULT_ID)
+        self._company_id = kwargs.get("company_id", DEFAULT_ID)
+        self._devices: List[DeviceItem] = kwargs.get("devices", [])
+        self._created_date = kwargs.get("created_date", DEFAULT_DATE)
+        self._updated_date = kwargs.get("updated_date", DEFAULT_DATE)
 
     # pylint: enable=too-many-arguments
 
     @property
     def id(self) -> ID:
-        assert self._id is not None
         return self._id
 
     @property
-    def user_id(self) -> Optional[ID]:
+    def user_id(self) -> ID:
         return self._user_id
 
     @property
-    def company_id(self) -> Optional[ID]:
+    def company_id(self) -> ID:
         return self._company_id
 
     @property
@@ -61,11 +81,11 @@ class DeviceLabel:
         return [] if self._devices is None else self._devices
 
     @property
-    def created_date(self) -> Optional[str]:
+    def created_date(self) -> str:
         return self._created_date
 
     @property
-    def updated_date(self) -> Optional[str]:
+    def updated_date(self) -> str:
         return self._updated_date
 
 

--- a/kentik_api_library/kentik_api/requests_payload/devices_payload.py
+++ b/kentik_api_library/kentik_api/requests_payload/devices_payload.py
@@ -89,7 +89,7 @@ class LabelPayload:
             company_id=convert(self.company_id, ID),
             created_date=self.cdate,
             updated_date=self.edate,
-            devices=None,
+            devices=[],
         )
 
 

--- a/kentik_api_library/kentik_api/requests_payload/labels_payload.py
+++ b/kentik_api_library/kentik_api/requests_payload/labels_payload.py
@@ -4,7 +4,7 @@ from typing import Optional, Dict, List, Any
 from dataclasses import dataclass
 
 # Local imports
-from kentik_api.requests_payload.conversions import convert
+from kentik_api.requests_payload.conversions import convert, convert_or_none
 from kentik_api.public.types import ID
 from kentik_api.public.device_label import DeviceLabel, DeviceItem
 
@@ -46,7 +46,7 @@ class GetResponse:
     id: int
     name: str
     color: str
-    user_id: str
+    user_id: Optional[str]
     company_id: str
     devices: _DeviceArray
     created_date: str
@@ -64,7 +64,7 @@ class GetResponse:
             name=self.name,
             color=self.color,
             id=convert(self.id, ID),
-            user_id=convert(self.user_id, ID),
+            user_id=convert_or_none(self.user_id, ID),
             company_id=convert(self.company_id, ID),
             devices=self.devices.to_device_items(),
             created_date=self.created_date,

--- a/kentik_api_library/tests/unit/api_resources/test_device_labels.py
+++ b/kentik_api_library/tests/unit/api_resources/test_device_labels.py
@@ -23,7 +23,7 @@ def test_create_device_label_success(client, connector) -> None:
     connector.response_code = HTTPStatus.CREATED
 
     # when
-    device_label = DeviceLabel("apitest-device_label-1", "#00FF00")
+    device_label = DeviceLabel(name="apitest-device_label-1", color="#00FF00")
     created = client.device_labels.create(device_label)
 
     # then request properly formed
@@ -96,7 +96,7 @@ def test_update_device_label_success(client, connector) -> None:
     {
         "id": 42,
         "name": "apitest-device_label-one",
-        "color": "#00FF00",
+        "color": "#AA00FF",
         "user_id": "52",
         "company_id": "72",
         "devices": [],
@@ -108,7 +108,7 @@ def test_update_device_label_success(client, connector) -> None:
 
     # when
     device_label_id = ID(42)
-    device_label = DeviceLabel(id=device_label_id, name="apitest-device_label-one")
+    device_label = DeviceLabel(id=device_label_id, name="apitest-device_label-one", color="#AA00FF")
     updated = client.device_labels.update(device_label)
 
     # then request properly formed
@@ -116,12 +116,12 @@ def test_update_device_label_success(client, connector) -> None:
     assert connector.last_method == APICallMethods.PUT
     assert connector.last_payload is not None
     assert connector.last_payload["name"] == "apitest-device_label-one"
-    assert "color" not in connector.last_payload
+    assert connector.last_payload["color"] == "#AA00FF"
 
     # then response properly parsed
     assert updated.id == ID(42)
     assert updated.name == "apitest-device_label-one"
-    assert updated.color == "#00FF00"
+    assert updated.color == "#AA00FF"
     assert updated.user_id == ID(52)
     assert updated.company_id == ID(72)
     assert updated.created_date == "2018-05-16T20:21:10.406Z"

--- a/kentik_api_library/tests/unit/public/test_device_label.py
+++ b/kentik_api_library/tests/unit/public/test_device_label.py
@@ -1,0 +1,64 @@
+from kentik_api.public.device_label import DeviceLabel, DeviceItem
+from kentik_api.public.types import ID
+
+
+def test_regular_constructor_success() -> None:
+    # given
+    name = "label1"
+    color = "#FF00AA"
+
+    # when
+    label = DeviceLabel(name=name, color=color)
+
+    # then
+    assert label.name == name
+    assert label.color == color
+
+
+def test_update_constructor_success() -> None:
+    # given
+    id = ID(100)
+    name = "label1"
+    color = "#FF00AA"
+
+    # when
+    label = DeviceLabel(id=id, name=name, color=color)
+
+    # then
+    assert label.id == id
+    assert label.name == name
+    assert label.color == color
+
+
+def test_internal_constructor_success() -> None:
+    # given
+    name = "label1"
+    color = "#FF00AA"
+    id = ID(100)
+    user_id = ID(300)
+    company_id = ID(700)
+    device = DeviceItem(id=ID(20), device_name="device1", device_subtype="aws", device_type="router")
+    created_date = "1970"
+    updated_date = "1971"
+
+    # when
+    label = DeviceLabel(
+        name=name,
+        color=color,
+        devices=[device],
+        id=id,
+        user_id=user_id,
+        company_id=company_id,
+        created_date=created_date,
+        updated_date=updated_date,
+    )
+
+    # then
+    assert label.name == name
+    assert label.color == color
+    assert label.id == id
+    assert label.user_id == user_id
+    assert label.company_id == company_id
+    assert len(label.devices) == 1
+    assert label.devices[0] == device
+    assert label.created_date == created_date


### PR DESCRIPTION
This is a proposal with example: remove overly used Optional from public classes, remove assertions from api_resources.
Do it by providing overloaded __init__ for Create, Update, Get in public classes.
Pros:
+constructor suggests the library user all the necessary arguments they need to supply to create valid DeviceLabel
+mypy checks the constructor call for mistakes
+no need to validate the object and throw exceptions in Runtime
Cons:
-way more complicated constructor from implementation point of view; may require unit testing
-Such approach assumes following flow for update: Request get object -> modify object -> Request update object. Updating without getting object from the server is not possible. Note: if needed, DeviceLabelUpdate with all fields optional can be implemented and smoothly incorporated in DeviceAPI facade - eg. by devices.update taking Union[DeviceLabel, DeviceLabelUpdate]