### PR TITLE
Safe and handy resources interface for library user - with factory methods

### DIFF
--- a/kentik_api_library/examples/labels_example.py
+++ b/kentik_api_library/examples/labels_example.py
@@ -44,7 +44,7 @@ def run_crud() -> None:
     client = KentikAPI(email, token)
 
     print("### CREATE")
-    label = DeviceLabel("apitest-label-1", "#0000FF")
+    label = DeviceLabel.new("apitest-label-1", "#0000FF")
     created = client.device_labels.create(label)
     print(created.__dict__)
     print()

--- a/kentik_api_library/kentik_api/api_resources/device_labels_api.py
+++ b/kentik_api_library/kentik_api/api_resources/device_labels_api.py
@@ -21,7 +21,6 @@ class DeviceLabelsAPI(BaseAPI):
         return labels_payload.GetResponse.from_json(response.text).to_device_label()
 
     def create(self, device_label: DeviceLabel) -> DeviceLabel:
-        assert device_label.color is not None
         apicall = device_labels.create_device_label()
         payload = labels_payload.CreateRequest(device_label.name, device_label.color)
         response = self.send(apicall, payload)

--- a/kentik_api_library/kentik_api/public/defaults.py
+++ b/kentik_api_library/kentik_api/public/defaults.py
@@ -1,0 +1,4 @@
+from kentik_api.public.types import ID
+
+DEFAULT_ID = ID(-1)
+DEFAULT_DATE = "1970-01-01T00:00:00.000Z"

--- a/kentik_api_library/kentik_api/public/device_label.py
+++ b/kentik_api_library/kentik_api/public/device_label.py
@@ -1,13 +1,12 @@
 from typing import List, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from kentik_api.public.types import ID
 from kentik_api.public.defaults import DEFAULT_ID, DEFAULT_DATE
 
 
-@dataclass
+@dataclass(frozen=True)
 class DeviceItem:
-
     id: ID
     device_name: str
     device_subtype: str
@@ -17,58 +16,23 @@ class DeviceItem:
 # pylint: disable=too-many-instance-attributes
 
 
+@dataclass
 class DeviceLabel:
-    # pylint: disable=too-many-arguments
-    def __init__(
-        self,
-        name: str,
-        color: str,
-        devices: List[DeviceItem],
-        id: ID,
-        user_id: ID,
-        company_id: ID,
-        created_date: str,
-        updated_date: str,
-    ) -> None:
-        # read-write
-        self.name = name
-        self.color = color
+    # read-write
+    name: str
+    color: str
 
-        # read-only
-        self._id = id
-        self._user_id = user_id
-        self._company_id = company_id
-        self._devices = devices
-        self._created_date = created_date
-        self._updated_date = updated_date
-
-    # pylint: enable=too-many-arguments
+    # read-only
+    _devices: List[DeviceItem] = field(default_factory=list)
+    _id: ID = DEFAULT_ID
+    _user_id: Optional[ID] = DEFAULT_ID
+    _company_id: ID = DEFAULT_ID
+    _created_date: str = DEFAULT_DATE
+    _updated_date: str = DEFAULT_DATE
 
     @classmethod
     def new(cls, name: str, color: str):
-        return cls(
-            name=name,
-            color=color,
-            devices=[],
-            id=DEFAULT_ID,
-            user_id=DEFAULT_ID,
-            company_id=DEFAULT_ID,
-            created_date=DEFAULT_DATE,
-            updated_date=DEFAULT_DATE,
-        )
-
-    @classmethod
-    def update(cls, id: ID, name: str, color: str):
-        return cls(
-            name=name,
-            color=color,
-            devices=[],
-            id=id,
-            user_id=DEFAULT_ID,
-            company_id=DEFAULT_ID,
-            created_date=DEFAULT_DATE,
-            updated_date=DEFAULT_DATE,
-        )
+        return cls(name=name, color=color)
 
     @property
     def id(self) -> ID:

--- a/kentik_api_library/kentik_api/public/device_label.py
+++ b/kentik_api_library/kentik_api/public/device_label.py
@@ -48,7 +48,7 @@ class DeviceLabel:
 
     @property
     def devices(self) -> List[DeviceItem]:
-        return [] if self._devices is None else self._devices
+        return self._devices
 
     @property
     def created_date(self) -> str:

--- a/kentik_api_library/kentik_api/public/device_label.py
+++ b/kentik_api_library/kentik_api/public/device_label.py
@@ -1,7 +1,8 @@
-from typing import List, Any, Optional
+from typing import List, Optional
 from dataclasses import dataclass
 
 from kentik_api.public.types import ID
+from kentik_api.public.defaults import DEFAULT_ID, DEFAULT_DATE
 
 
 @dataclass
@@ -21,13 +22,13 @@ class DeviceLabel:
     def __init__(
         self,
         name: str,
-        color: Optional[str] = None,
-        id: Optional[ID] = None,
-        user_id: Optional[ID] = None,
-        company_id: Optional[ID] = None,
-        devices: Optional[List[DeviceItem]] = None,
-        created_date: Optional[str] = None,
-        updated_date: Optional[str] = None,
+        color: str,
+        devices: List[DeviceItem],
+        id: ID,
+        user_id: ID,
+        company_id: ID,
+        created_date: str,
+        updated_date: str,
     ) -> None:
         # read-write
         self.name = name
@@ -43,9 +44,34 @@ class DeviceLabel:
 
     # pylint: enable=too-many-arguments
 
+    @classmethod
+    def new(cls, name: str, color: str):
+        return cls(
+            name=name,
+            color=color,
+            devices=[],
+            id=DEFAULT_ID,
+            user_id=DEFAULT_ID,
+            company_id=DEFAULT_ID,
+            created_date=DEFAULT_DATE,
+            updated_date=DEFAULT_DATE,
+        )
+
+    @classmethod
+    def update(cls, id: ID, name: str, color: str):
+        return cls(
+            name=name,
+            color=color,
+            devices=[],
+            id=id,
+            user_id=DEFAULT_ID,
+            company_id=DEFAULT_ID,
+            created_date=DEFAULT_DATE,
+            updated_date=DEFAULT_DATE,
+        )
+
     @property
     def id(self) -> ID:
-        assert self._id is not None
         return self._id
 
     @property
@@ -53,7 +79,7 @@ class DeviceLabel:
         return self._user_id
 
     @property
-    def company_id(self) -> Optional[ID]:
+    def company_id(self) -> ID:
         return self._company_id
 
     @property
@@ -61,11 +87,11 @@ class DeviceLabel:
         return [] if self._devices is None else self._devices
 
     @property
-    def created_date(self) -> Optional[str]:
+    def created_date(self) -> str:
         return self._created_date
 
     @property
-    def updated_date(self) -> Optional[str]:
+    def updated_date(self) -> str:
         return self._updated_date
 
 

--- a/kentik_api_library/kentik_api/requests_payload/devices_payload.py
+++ b/kentik_api_library/kentik_api/requests_payload/devices_payload.py
@@ -83,14 +83,14 @@ class LabelPayload:
 
     def to_device_label(self) -> DeviceLabel:
         return DeviceLabel(
-            id=convert(self.id, ID),
             color=self.color,
             name=self.name,
-            user_id=convert(self.user_id, ID),
-            company_id=convert(self.company_id, ID),
-            created_date=self.cdate,
-            updated_date=self.edate,
-            devices=[],
+            _id=convert(self.id, ID),
+            _user_id=convert(self.user_id, ID),
+            _company_id=convert(self.company_id, ID),
+            _created_date=self.cdate,
+            _updated_date=self.edate,
+            _devices=[],
         )
 
 

--- a/kentik_api_library/kentik_api/requests_payload/devices_payload.py
+++ b/kentik_api_library/kentik_api/requests_payload/devices_payload.py
@@ -90,7 +90,7 @@ class LabelPayload:
             company_id=convert(self.company_id, ID),
             created_date=self.cdate,
             updated_date=self.edate,
-            devices=None,
+            devices=[],
         )
 
 

--- a/kentik_api_library/kentik_api/requests_payload/labels_payload.py
+++ b/kentik_api_library/kentik_api/requests_payload/labels_payload.py
@@ -3,7 +3,7 @@ from typing import Optional, Dict, List, Any
 from dataclasses import dataclass
 
 # Local imports
-from kentik_api.requests_payload.conversions import convert, from_dict, dict_from_json, list_from_json
+from kentik_api.requests_payload.conversions import convert, convert_or_none, from_dict, dict_from_json, list_from_json
 from kentik_api.public.types import ID
 from kentik_api.public.device_label import DeviceLabel, DeviceItem
 
@@ -45,7 +45,7 @@ class GetResponse:
     id: int
     name: str
     color: str
-    user_id: str
+    user_id: Optional[str]
     company_id: str
     devices: _DeviceArray
     created_date: str
@@ -62,12 +62,12 @@ class GetResponse:
         return DeviceLabel(
             name=self.name,
             color=self.color,
-            id=convert(self.id, ID),
-            user_id=convert(self.user_id, ID),
-            company_id=convert(self.company_id, ID),
-            devices=self.devices.to_device_items(),
-            created_date=self.created_date,
-            updated_date=self.updated_date,
+            _id=convert(self.id, ID),
+            _user_id=convert_or_none(self.user_id, ID),
+            _company_id=convert(self.company_id, ID),
+            _devices=self.devices.to_device_items(),
+            _created_date=self.created_date,
+            _updated_date=self.updated_date,
         )
 
 

--- a/kentik_api_library/tests/unit/api_resources/test_device_labels.py
+++ b/kentik_api_library/tests/unit/api_resources/test_device_labels.py
@@ -104,15 +104,26 @@ def test_update_device_label_success() -> None:
         "company_id": "72",
         "devices": [],
         "created_date": "2018-05-16T20:21:10.406Z",
-        "updated_date": "2018-05-16T20:21:10.406Z"
+        "updated_date": "2018-06-16T20:21:10.406Z"
     }"""
     connector = StubAPIConnector(update_response_payload, HTTPStatus.OK)
     device_labels_api = DeviceLabelsAPI(connector)
+    device_label_id = ID(42)
+    existing_label = DeviceLabel(
+        name="apitest-device_label",
+        color="#00FF00",
+        _devices=[],
+        _id=device_label_id,
+        _user_id=ID(52),
+        _company_id=ID(72),
+        _created_date="2018-05-16T20:21:10.406Z",
+        _updated_date="2018-05-16T20:21:10.406Z",
+    )
 
     # when
-    device_label_id = ID(42)
-    device_label = DeviceLabel.update(id=device_label_id, name="apitest-device_label-one", color="#AA00FF")
-    updated = device_labels_api.update(device_label)
+    existing_label.name = "apitest-device_label-one"
+    existing_label.color = "#AA00FF"
+    updated = device_labels_api.update(existing_label)
 
     # then request properly formed
     assert connector.last_url_path == f"/deviceLabels/{device_label_id}"
@@ -128,7 +139,7 @@ def test_update_device_label_success() -> None:
     assert updated.user_id == ID(52)
     assert updated.company_id == ID(72)
     assert updated.created_date == "2018-05-16T20:21:10.406Z"
-    assert updated.updated_date == "2018-05-16T20:21:10.406Z"
+    assert updated.updated_date == "2018-06-16T20:21:10.406Z"
     assert len(updated.devices) == 0
 
 
@@ -162,7 +173,7 @@ def test_get_all_device_labels_success() -> None:
             "id": 41,
             "name": "device_labels_1",
             "color": "#5289D9",
-            "user_id": "136885",
+            "user_id": null,
             "company_id": "74333",
             "devices": [],
             "created_date": "2020-11-20T12:54:49.575Z",
@@ -205,6 +216,7 @@ def test_get_all_device_labels_success() -> None:
 
     # then response properly parsed
     assert len(labels) == 2
+    assert labels[0].user_id is None  # API allows user_id to be None
     assert labels[1].id == ID(42)
     assert labels[1].name == "device_labels_2"
     assert labels[1].color == "#3F4EA0"

--- a/kentik_api_library/tests/unit/api_resources/test_device_labels.py
+++ b/kentik_api_library/tests/unit/api_resources/test_device_labels.py
@@ -26,7 +26,7 @@ def test_create_device_label_success() -> None:
     device_labels_api = DeviceLabelsAPI(connector)
 
     # when
-    device_label = DeviceLabel(name="apitest-device_label-1", color="#00FF00")
+    device_label = DeviceLabel.new(name="apitest-device_label-1", color="#00FF00")
     created = device_labels_api.create(device_label)
 
     # then request properly formed
@@ -111,7 +111,7 @@ def test_update_device_label_success() -> None:
 
     # when
     device_label_id = ID(42)
-    device_label = DeviceLabel(id=device_label_id, name="apitest-device_label-one", color="#AA00FF")
+    device_label = DeviceLabel.update(id=device_label_id, name="apitest-device_label-one", color="#AA00FF")
     updated = device_labels_api.update(device_label)
 
     # then request properly formed


### PR DESCRIPTION
This is a proposal with example: remove overly used Optional from public classes, remove assertions from api_resources.
Do it by providing factory methods for resource create and update in public classes.
Pros:
+factory method suggests the library user all the necessary arguments they need to supply to create valid DeviceLabel
+mypy checks the factory method call for mistakes
+no need to validate the object and throw exceptions in Runtime
Cons:
-may seem less "pythonic"
-Such approach assumes following flow for update: Request get object -> modify object -> Request update object. Updating without getting object from the server is not possible. Note: if needed, DeviceLabelUpdate with all fields optional can be implemented and smoothly incorporated in DeviceAPI facade - eg. by devices.update taking Union[DeviceLabel, DeviceLabelUpdate]