### PR TITLE
Relaxed input verification in convert_or_none

### DIFF
--- a/kentik_api_library/kentik_api/requests_payload/conversions.py
+++ b/kentik_api_library/kentik_api/requests_payload/conversions.py
@@ -110,7 +110,7 @@ def convert(attr: Any, convert_func) -> Any:
 def convert_or_none(attr: Any, convert_func) -> Optional[Any]:
     """ Convert if input is not None, else just return None. Raise DataFormatError on failure  """
 
-    if attr is None or attr == {}:
+    if not attr:
         return None
     return convert(attr, convert_func)
 


### PR DESCRIPTION
Turn any empty value (Python "false") into None. This allows to reasonably handle unexpected, but likely harmless (data free) values in responses from Kentik API.

Example use case:

Handling of empty strings in `cdn_attr` values in response to `device list` request.