### PR TITLE
Fix payload for devices.interfaces.get_all API call

### DIFF
--- a/kentik_api_library/kentik_api/public/device.py
+++ b/kentik_api_library/kentik_api/public/device.py
@@ -264,6 +264,9 @@ class Device:
     def all_interfaces(self) -> List[Any]:
         return list(self._all_interfaces) if self._all_interfaces is not None else []
 
+    def has_label(self, label: str):
+        return label in [lbl.name for lbl in self.labels]
+
     @classmethod
     def new_router(
         cls,

--- a/kentik_api_library/kentik_api/public/device.py
+++ b/kentik_api_library/kentik_api/public/device.py
@@ -264,9 +264,6 @@ class Device:
     def all_interfaces(self) -> List[Any]:
         return list(self._all_interfaces) if self._all_interfaces is not None else []
 
-    def has_label(self, label: str):
-        return label in [lbl.name for lbl in self.labels]
-
     @classmethod
     def new_router(
         cls,

--- a/kentik_api_library/kentik_api/requests_payload/interfaces_payload.py
+++ b/kentik_api_library/kentik_api/requests_payload/interfaces_payload.py
@@ -39,15 +39,15 @@ class TopNextHopASNPayload:
     """This datastructure represents JSON Interface.TopNextHopASN payload as it is transmitted to and from KentikAPI"""
 
     # GET, POST, PUT request/response
-    ASN: int
-    packets: int
+    Asn: int
+    Packets: int
 
     @classmethod
     def from_dict(cls, dic: Dict[str, Any]):
         return from_dict(data_class=cls, data=dic)
 
     def to_top_next_hop_asn(self) -> TopNextHopASN:
-        return TopNextHopASN(asn=self.ASN, packets=self.packets)
+        return TopNextHopASN(asn=self.Asn, packets=self.Packets)
 
 
 @dataclass

--- a/kentik_api_library/tests/unit/api_resources/test_devices.py
+++ b/kentik_api_library/tests/unit/api_resources/test_devices.py
@@ -1673,13 +1673,13 @@ def test_get_interface_full_success() -> None:
             "initial_network_boundary": "",
             "top_nexthop_asns": [
                 {
-                    "ASN": 20,
-                    "packets":30100
+                    "Asn": 20,
+                    "Packets":30100
                 },
                 {
-                    "ASN": 21,
+                    "Asn": 21,
                     "fala": "hala",
-                    "packets":30101
+                    "Packets":30101
                 }
             ],
             "provider": "",
@@ -1808,12 +1808,12 @@ def test_get_all_interfaces_success() -> None:
             "initial_network_boundary": "",
             "top_nexthop_asns": [
                 {
-                    "ASN": 20,
-                    "packets":30100
+                    "Asn": 20,
+                    "Packets":30100
                 },
                 {
-                    "ASN": 21,
-                    "packets":30101
+                    "Asn": 21,
+                    "Packets":30101
                 }
             ],
             "provider": "",


### PR DESCRIPTION
Kentik API actually returns `Asn` and `Packets` (as opposed to `ASN` and `packets`) in the `topn_nexthops_asn` sections of `devices.interfaces.get_all` response payload which makes requests to fail with `DeserializationError: TopNextHopASNPayload: missing value for field "ASN"`, if the `topn_nexthops_asn` field is non-empty in the response.