### PR TITLE
Add support for mapping data retrieved with topXdata query to pandas DataFrames

### DIFF
--- a/kentik_api_library/README.md
+++ b/kentik_api_library/README.md
@@ -111,7 +111,8 @@ List of available examples:
 - [tags_example.py](./examples/tags_example.py) - create/update/get/delete/list Tags
 - [users_example.py](./examples/users_example.py) - create/update/get/delete/list Users
 - [error_handling_example.py](./examples/error_handling_example.py) - handling errors raised by the library
-- [analytics_example.py](./examples/analytics_example.py) - use of the `flatness_analysis` method and the`DeviceCache`
+- [analytics_example_sql.py](./examples/analytics_example_sql.py) - use of `SQLQueryDefinition`, `flatness_analysis` method and the`DeviceCache`
+- [analytics_example_topx.py](./examples/analytics_example_sql.py) - use of `DataQueryDefinition`, `flatness_analysis` method and the`DeviceCache`
   (see also [analytics readme](./kentik_api/analytics/README.md))
 
 ## Open-source libraries

--- a/kentik_api_library/examples/analytics_example_sql.py
+++ b/kentik_api_library/examples/analytics_example_sql.py
@@ -1,10 +1,10 @@
 import logging
 from datetime import datetime, timedelta, timezone
+
 from kentik_api import KentikAPI
-from kentik_api.utils import get_credentials, DeviceCache
 from kentik_api.analytics import SQLQueryDefinition, flatness_analysis
 from kentik_api.analytics.flatness import freq_to_seconds
-
+from kentik_api.utils import DeviceCache, get_credentials
 
 logging.basicConfig(level=logging.INFO)
 
@@ -32,8 +32,8 @@ def main() -> None:
         print("No devices available.")
         return
     print(f"Got {devices.count} devices")
-    print("Fetching flow data ...", end=" ")
-    end = datetime.now(timezone.utc)
+    print("Fetching flow data (using SQL query) ...", end=" ")
+    end = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
     start = end - timedelta(hours=23, minutes=59)
     df = query.get_data(api, start=start, end=end)
     if df.shape[0] < 1:

--- a/kentik_api_library/examples/analytics_example_topx.py
+++ b/kentik_api_library/examples/analytics_example_topx.py
@@ -1,0 +1,108 @@
+import logging
+from datetime import datetime, timedelta, timezone
+
+from pandas import DataFrame
+
+from kentik_api import KentikAPI
+from kentik_api.analytics import DataQueryDefinition, dedup_data_frame, flatness_analysis
+from kentik_api.utils import DeviceCache, get_credentials
+
+logging.basicConfig(level=logging.INFO)
+
+query_data = {
+    "query": {
+        "queries": [
+            {
+                "bucket": "flow",
+                "query": {
+                    "starting_time": "{start}",
+                    "ending_time": "{end}",
+                    "aggregates": [
+                        {"column": "f_sum_both_bytes", "fn": "average", "name": "avg_bits_per_sec", "raw": True}
+                    ],
+                    "all_devices": True,
+                    "dimension": ["i_device_id", "InterfaceID_dst"],
+                    "fastData": "Full",
+                    "filters": {
+                        "connector": "All",
+                        "filterGroups": [
+                            {
+                                "connector": "All",
+                                "filters": [
+                                    {
+                                        "filterField": "i_dst_network_bndry_name",
+                                        "filterValue": "external",
+                                        "operator": "=",
+                                    },
+                                    {"filterField": "i_trf_termination", "filterValue": "outside", "operator": "="},
+                                ],
+                                "not": False,
+                            }
+                        ],
+                    },
+                    "metric": ["bytes"],
+                    "time_format": "UTC",
+                    "topx": 125,
+                },
+            }
+        ]
+    },
+    "mappings": {
+        "all": {
+            "link": {"source": "{i_device_name}:{output_port}", "type": '@fixup: lambda x: x.split(" : ")[0]'},
+            "bps_out": {"source": "@TS.both_bits_per_sec.value", "type": "float64"},
+            "avg_bps_out": {"source": "{avg_bits_per_sec}", "type": "float64"},
+            "period": {"source": "@TS.both_bits_per_sec.period", "type": "int64"},
+            "ts": {"source": "@TS.both_bits_per_sec.timestamp", "index": True},
+        }
+    },
+}
+
+
+def main() -> None:
+    api = KentikAPI(*get_credentials())
+    query = DataQueryDefinition.from_dict(query_data)
+    print("Fetching devices ...", end=" ")
+    devices = DeviceCache.from_api(api)
+    if devices.count < 1:
+        print("No devices available.")
+        return
+    print(f"Got {devices.count} devices")
+    print("Fetching flow data (using topXdata query) ...", end=" ")
+    end = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    start = end - timedelta(hours=23, minutes=59)
+    r = query.get_data(api, start=start, end=end)
+    df = r.get("flow", DataFrame())
+    if df.shape[0] < 1:
+        print("Got no flow data")
+        return
+    print(f"Got {df.shape[0]} entries, time resolution {df.period.max()} seconds")
+    # topXdata query may return duplicate time series entries, need to de-duplicate
+    df = dedup_data_frame(df, ["ts", "link"])
+
+    time_window = timedelta(minutes=60)
+    flatness_limit = 0.5
+    min_utilization = 5
+    max_utilization = 100 - flatness_limit
+
+    print("Analysis parameters:")
+    print("\ttime_window:     ", time_window)
+    print("\tflatness_limit:  ", flatness_limit)
+    print("\tmin_utilization: ", min_utilization)
+    print("\tmax_utilization: ", max_utilization)
+
+    results = flatness_analysis(
+        devices=devices,
+        data=df,
+        flatness_limit=flatness_limit,
+        window=time_window,
+        min_valid=min_utilization,
+        max_valid=max_utilization,
+    )
+
+    print("-" * 25)
+    results.to_text()
+
+
+if __name__ == "__main__":
+    main()

--- a/kentik_api_library/kentik_api/analytics/README.md
+++ b/kentik_api_library/kentik_api/analytics/README.md
@@ -7,22 +7,126 @@ is installed with the `analytics` option (`kentik-api[analytics]`).
 The sub-module provides:
 
 ## Retrieval of Kentik query results in pandas DataFrame
-Retrieval of Kentik data in a DataFrame is supported via "mapped queries". Currently only `SQLMappedQuery` implementation
-is available. It allows to issue SQL query via Kentik API and map response data into DataFrame. Instance of `SQLMappedQuery`
-class can be constructed either based on dictionary (the `SQLMappedQuery.from_dict` factory method) or YAML data
-(`SQLMappedQuery.from_file` method). The format is the same in both cases:
+Retrieval of Kentik data in a DataFrame is supported via "mapped queries". Mapped queries are provided both for `topXdata`
+queries (class `DataQueryDefinition`) and `sql` queries (class `SQLQueryDefinition`). Behavior differs due to inherent
+differences in those 2 query methods. In both cases, the `*QueryDefinition` classes contain:
+- query template
+- response mapping for constructing DataFrame from returned data
+For both query types, mapped query objects can be constructed based on YAML formatted files.
 
+#### Query templates
+Query templates obviously differ for both types of queries, however in both cases they can be parametrized by
+inserting `str.format` style directives which allow to insert specific values at runtime. For example, if you
+want to insert beginning of the queried interval, include `{start_time}` placeholder where the value is expected in
+the query and then provide `start_time=<desired_start_time>` among arguments to the `{Data|SQL}MappedQuery.get_data()`
+method. Any value that can be expanded using `str.format` syntax can be interpolated at runtime.
+
+#### Response mapping
+Result mapping represented by `ResultMapping` class is (basically) a dictionary keyed by output DataFrame columns names
+with entries providing data for constructing values of the column from Kentik API query responses. Individual
+mapping entries are represented by the `MappingEntry` class. Mapping entries contain following attributes:
+- `source`: string containing `str.format`-style formatting string for extracting specific result data fields. Special
+          directives, prefixed with @TS allow extracting data from `topXdata` result `timeSeries` blocks (and hence are
+          applicable only the context of `DataMappedQuery`)
+- `type`: optional string containing desired data type for column values. Any `numpy.dtype` and Python
+          type name is accepted. In addition, following special type strings are provided:
+          - `time`: converts string to pandas.datetime object
+          - `unix_timestamp`: converts integer Unix epoch timestamp to pandas.datetime object
+          - `unix_timestamp_millis`: converts integer Unix epoch millisecond timestamp to pandas.datetime object
+          - `@fixup: <python lambda>`: allows applying a lambda function to every value in the columns. Example:
+                 type: `@fixup: lambda x: x.split(".")[0]` results in calling
+                 `DataFrame.transform(lambda x: x.split(".")[0])` for all values in the column
+
+- `index`: boolean indicating whether columns should be used as index for resulting DataFrame. If multiple entries
+           in a mapping have it set, resulting DataFrame is multi-indexed.
+
+#### DataQueryDefinition
+This class allows issuing `topXdata` query (which allows to issue one or more KDE queries) and mapping results to
+DataFrames (one DataFrame per result entry). Query template can be specified either as JSON string or an equivalent
+dictionary. An easy way to get valid JSON for a specific query is to use Kentik Data Explorer to construct it.
+JSON payload can be exported using`Actions -> Show API Call -> JSON Input` menu item.
+Result mapping for `topXdata` query results allows constructing DataFrames both based on aggregate values and
+time series data (returned if `raw` attribute is set to `true` in definition of an aggregate in the query). Time series
+data are extracted by specifying `@TS.<variable>.*` in `source` field of a mapping entry. There are 3 types of `@TS`
+source specifications:
+- `@TS.<variable>.timestamp` extracts timestamp field
+- `@TS.<variable>.value` extracts variable value field
+- `@TS.<variable>.period` extracts sampling period field
+
+In all cases, the `<variable>` refers to the name of the `timeSeries` keys in the response block. Time series names
+correspond with aggregates specified in the query (for which `raw` attribute was set to `true`). Unfortunately
+names of time series cannot be easily established and must be figured out by issuing a query and inspecting response.
+If mapping specifies at least one `@TS` source, number of rows in the resulting DataFrame is equal to number of 
+entries in the result time number of entries in a time series (all time series have the same length in each result set).
+Values for any non-`@TS` columns are replicated for each timestamp.
+
+Each instance of `DataQueryDefinition` contains a dictionary keyed by query `bucket` values and containing instance of
+`ResultMapping` for the specific query. Result mapping for an result entry is matched by value of the `bucket`
+attribute. If no match is found in the mapping dictionary, mapping with key `all` is used if present. Result mapping is
+mandatory in `DataQueryDefinition` as there is no meaningful canonical way to map `topXdata` responses to DataFrames.
+
+The `DataQueryDefinition.get_data(api, **kwargs)` method executes query after expanding the template using parameters
+provided in `kwargs` and then maps returned data (if any) to DataFrames. It returns dictionary keyed by values of
+the `bucket` attribute in each response entry (which corresponds to `bucket` attribute in query).
+
+Example `DataQueryDefinition` in YAML format:
+```yaml
+query:
+  queries:
+  - bucket: simple
+    query:
+      aggregates:
+      - column: f_sum_both_bytes
+        fn: average
+        name: avg_bits_per_sec
+        raw: true
+      all_devices: true
+      dimension:
+      - Traffic
+      ending_time: '{end}'
+      fastData: Full
+      metric:
+      - bytes
+      starting_time: '{start}'
+      time_format: UTC
+      topx: 125
+  version: 4
+
+mappings:
+  all:
+    ts:
+      source: '@TS.both_bits_per_sec.timestamp'
+      index: true
+    bps:
+      source: '@TS.both_bits_per_sec.value'
+      type: float
+    period:
+      source: '@TS.both_bits_per_sec.period'
+      type: int64
+    avg_bps:
+      source: '{avg_bits_per_sec}'
+      type: float64
 ```
+The query template in the definition above has 2 parameters `start` and `end`. Output from
+`DataQueryDefinition.get_data(api, start=<time>, end=,=<time>)` call is a dictionary with one key `simple` containing
+DataFrame with`bps`, `period` and `avg_bps` columns and indexed by time.
+
+#### SQLQueryDefinition
+This class allows issuing SQL query via Kentik API and mapping response data into DataFrame. Instance of `SQLMappedQuery`
+class can be constructed either based on dictionary (the `SQLQueryDefinition.from_dict` factory method) or YAML data
+(`SQLQueryDefinition.from_file` method). The format is the same in both cases:
+
+```yaml
 query: <verbatim text of SQL query with optional {str.format} placeholders>,
 mapping:
 <DataFrame column name>:
   - source: <str.format string constructing value from SQL row>
-  - type: <"time" or pandas.dtype string>
+  - type: <data type specification>
   - index: <bool>
 ...
 ```
 Where:
-- the `query` field is required. It is expected to contain Ketnik SQL query template. Final SQL query is constructed by
+- the `query` field is required. It is expected to contain Kentik SQL query template. Final SQL query is constructed by
   the `SQLQueryDefinition.to_sql(**kwargs)` method. The content of the `query` field is used as `str.format` format string
   and `kwargs` are passed as arguments. `kwargs` must provide value for each named variable used in formatting constructs
   in the query template. For example, for `query`:
@@ -62,6 +166,7 @@ All cached DataFrames are expected to have identical format (`DFCache.get()` fai
 
 ## Analytic methods processing Pandas DataFrames
 At the moment, only one analytic method is provided
+
 ### Detection of constant link utilization (`flatness`)
 This method allows to detect intervals of constant traffic on a set of network links. Network link = `device:interface` tuple.
 Non-zero and non-saturating "flat" traffic in outbound direction on perimeter links can be used as an indication of

--- a/kentik_api_library/kentik_api/analytics/__init__.py
+++ b/kentik_api_library/kentik_api/analytics/__init__.py
@@ -9,4 +9,4 @@ except ImportError:
 
 from .data_frame_cache import DFCache
 from .flatness import FlatnessResults, flatness_analysis
-from .mapped_query import SQLQueryDefinition
+from .mapped_query import SQLQueryDefinition, DataQueryDefinition

--- a/kentik_api_library/kentik_api/analytics/__init__.py
+++ b/kentik_api_library/kentik_api/analytics/__init__.py
@@ -7,6 +7,6 @@ try:
 except ImportError:
     raise RuntimeError("Analytics support requires 'pyyaml'")
 
-from .data_frame_cache import DFCache
+from .data_frame_cache import DFCache, dedup_data_frame
 from .flatness import FlatnessResults, flatness_analysis
-from .mapped_query import SQLQueryDefinition, DataQueryDefinition
+from .mapped_query import DataQueryDefinition, SQLQueryDefinition

--- a/kentik_api_library/kentik_api/analytics/flatness.py
+++ b/kentik_api_library/kentik_api/analytics/flatness.py
@@ -381,7 +381,6 @@ def flatness_analysis(
     bad = link_util[(link_util.utilization > 100) & (link_util.utilization != float("Inf"))].shape[0]
     if bad > 0:
         log.critical("%d data samples with link utilization > 100%%", bad)
-        data.loc[data.utilization > 100, "utilization"] = 100.0
     log.debug("Computing traffic statistics")
     stats = compute_stats(link_util, window=window)
     log.debug("Analyzing flatness")

--- a/kentik_api_library/kentik_api/analytics/flatness.py
+++ b/kentik_api_library/kentik_api/analytics/flatness.py
@@ -381,6 +381,7 @@ def flatness_analysis(
     bad = link_util[(link_util.utilization > 100) & (link_util.utilization != float("Inf"))].shape[0]
     if bad > 0:
         log.critical("%d data samples with link utilization > 100%%", bad)
+        data.loc[data.utilization > 100, "utilization"] = 100.0
     log.debug("Computing traffic statistics")
     stats = compute_stats(link_util, window=window)
     log.debug("Analyzing flatness")

--- a/kentik_api_library/kentik_api/analytics/mapped_query.py
+++ b/kentik_api_library/kentik_api/analytics/mapped_query.py
@@ -25,7 +25,7 @@ class MappingEntry:
     """
     Class describing single mapping entry for construction of a DataFrame from KDE API 'sql' or 'topXdata' result.
     Attributes:
-        'source': string containing 'str.format' formatting string for extacting specific result data field. Special
+        'source': string containing 'str.format' formatting string for extracting specific result data field. Special
                   directives, prefixed with @TS allow to extract data from 'topXdata' result 'timeSeries' blocks
         'data_type': optional string containing desired data type for column values. Any numpy.dtype and Python
                   type name is accepted. In addition to that, following special type strings are provided:
@@ -389,8 +389,12 @@ def data_result_to_df(mappings: Dict[str, ResultMapping], data: QueryDataResult)
                 ]
                 if missing_ts:
                     raise RuntimeError(
-                        "result[{i}]: label: {label}: No 'timeSeries' for variables(s) '{mts}' in entry '{e}'".format(
-                            i=i, label=result_label, mts=",".join([str(x) for x in missing_ts]), e=e
+                        "result[{i}]: label: {label}: Entry has no time series for variables '{mts}' "
+                        "(available time series: '{ts_keys}')".format(
+                            i=i,
+                            label=result_label,
+                            mts=",".join([str(x) for x in missing_ts]),
+                            ts_keys=",".join(e["timeSeries"].keys()),
                         )
                     )
                 ts_len = set(

--- a/kentik_api_library/kentik_api/analytics/mapped_query.py
+++ b/kentik_api_library/kentik_api/analytics/mapped_query.py
@@ -1,15 +1,16 @@
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Callable, Dict, Generator, Optional, Tuple, Type, TypeVar
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union
 
 import yaml
+import json
 from pandas import DataFrame, to_datetime
 
 from kentik_api import KentikAPI
-from kentik_api.public import QuerySQL, QuerySQLResult
+from kentik_api.public import QuerySQL, QuerySQLResult, QueryObject, QueryDataResult
 
-MappedQueryFn = Callable[..., DataFrame]
+MappedQueryFn = Callable[..., Union[DataFrame, Dict[str, DataFrame]]]
 
 
 @dataclass
@@ -19,12 +20,12 @@ class MappingEntry:
     is_index: bool = False
 
 
-T = TypeVar("T", bound="SQLResultMapping")
+SQLResultMappingType = TypeVar("SQLResultMappingType", bound="SQLResultMapping")
 
 
 class SQLResultMapping:
     @classmethod
-    def from_dict(cls: Type[T], data: Optional[Dict] = None) -> T:
+    def from_dict(cls: Type[SQLResultMappingType], data: Optional[Dict] = None) -> SQLResultMappingType:
         mapping = cls()
         if data is None:
             return mapping
@@ -131,3 +132,134 @@ def sql_result_to_df(mapping: SQLResultMapping, sql_data: QuerySQLResult) -> Opt
             df.sort_index(inplace=True)
     logging.debug("df shape: (%d, %d)", df.shape[0], df.shape[1])
     return df
+
+
+DataResultMappingType = TypeVar("DataResultMappingType", bound="DataResultMapping")
+
+
+class DataResultMapping:
+    @classmethod
+    def from_dict(cls: Type[DataResultMappingType], data: Optional[Dict] = None) -> DataResultMappingType:
+        mapping = cls()
+        if data is None:
+            return mapping
+        for c, d in data.items():
+            if mapping.has(c):
+                raise RuntimeError(f"Duplicate mapping for column '{c}' in query definition ({data})")
+            if type(d) != dict or "source" not in d.keys():
+                raise RuntimeError(f"'source' is missing in query definition entry for column {c} ({data})")
+            mapping[c] = MappingEntry(format=d["source"], data_type=d.get("type"), is_index=d.get("index", False))
+        return mapping
+
+    def __init__(self, entries: Optional[Dict[str, MappingEntry]] = None) -> None:
+        self._entries: Dict[str, MappingEntry] = dict()
+        if entries:
+            self._entries.update(entries)
+
+    def __getitem__(self, column):
+        return self._entries.get(column)
+
+    def __setitem__(self, key: str, value: MappingEntry) -> None:
+        self._entries[key] = value
+
+    def has(self, column) -> bool:
+        return column in self._entries
+
+    def items(self) -> Generator[Tuple[str, MappingEntry], None, None]:
+        for k, v in self._entries.items():
+            yield k, v
+
+    @property
+    def is_empty(self) -> bool:
+        return len(self._entries) == 0
+
+
+class DataQueryDefinition:
+    @classmethod
+    def from_file(cls, filename: str):
+        with open(filename, "r") as f:
+            qd = yaml.load(f, yaml.SafeLoader)
+        logging.debug("Loading query definition: %s from %s", qd, filename)
+        return cls.from_dict(qd)
+
+    @classmethod
+    def from_dict(cls, qd: dict):
+        if "query" not in qd:
+            raise RuntimeError(f"No query template in query definition: {qd}")
+        return cls(query=qd["query"], mapping=DataResultMapping.from_dict(qd.get("mapping")))
+
+    def __init__(self, query: Union[str, Dict], mapping: DataResultMapping) -> None:
+        if type(query) == str:
+            self.query = json.loads(query)
+        else:
+            self.query = query
+        self.mapping = mapping
+
+    def expand_query(self, **kwargs) -> Dict:
+        def _expand_dict(data: Dict, parent: str, **kwargs) -> Dict:
+            return {k: _expand(v, parent=f"{parent}.{k}", **kwargs) for k, v in data.items()}
+
+        def _expand_list(data: List, parent: str , **kwargs) -> List:
+            return [_expand(v, parent=f"{parent}[{i}]", **kwargs) for i, v in enumerate(data)]
+
+        def _expand(data: Any, parent: str, **kwargs) -> Any:
+            if type(data) == dict:
+                return _expand_dict(data, parent, **kwargs)
+            elif type(data) == list:
+                return _expand_list(data, parent, **kwargs)
+            elif type(data) == str:
+                logging.debug("key: %s expanding: '%s'", f"{parent}", data)
+                r = data.format(**kwargs)
+                logging.debug("got: '%s'", r)
+                return r
+            else:
+                return data
+        return _expand(self.query, parent="", **kwargs)
+
+    def query_object(self, **kwargs) -> QueryObject:
+        """
+        Produce SQL query object from template by expanding embedded str.format directives using data in kwargs
+        """
+        return QueryObject.from_dict(self.expand_query(**kwargs))
+
+    def get_data(self, api: KentikAPI, **kwargs) -> Dict[str, DataFrame]:
+        result = api.query.data(self.query_object(**kwargs))
+        return data_result_to_df(self.mapping, result)
+
+    def make_query_fn(self, api: KentikAPI) -> MappedQueryFn:
+        """
+        Create a function returning DataFrame based on the query definition
+        The main purpose is to pass the function to the DFCache.fetch method
+        """
+
+        def data_mapped_query(**kwargs) -> Dict[str, DataFrame]:
+            return self.get_data(api, **kwargs)
+
+        return data_mapped_query
+
+
+def data_result_to_df(mapping: DataResultMapping, data: QueryDataResult) -> Dict[str, DataFrame]:
+    """
+    Map KDE SQL query result to Pandas DataFrame
+    If no mapping is provided in query definition, every column in response row is included as DataFrame columns
+    otherwise data are mapped to DataFrame based on mapping entries
+    """
+    if len(data.results) < 1:
+        logging.debug("No data in query result")
+        return None
+    if mapping.is_empty:
+        logging.error("Empty mapping")
+        raise RuntimeError("Mapping is required to transform data query results to DataFrames")
+    out = dict()
+    for r in data.results:
+        raise RuntimeError("Code is not finished")
+
+    # INSERT DATA MAPPING
+
+        columns = defaultdict(list)
+        df = DataFrame.from_dict(data)
+        apply_data_types(df, mapping)
+        logging.debug("df shape: (%d, %d)", df.shape[0], df.shape[1])
+        out[r.bucket] = df
+    return out
+

--- a/kentik_api_library/kentik_api/analytics/mapped_query.py
+++ b/kentik_api_library/kentik_api/analytics/mapped_query.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union
 
+import re
 import yaml
 import json
 from pandas import DataFrame, to_datetime
@@ -10,14 +11,60 @@ from pandas import DataFrame, to_datetime
 from kentik_api import KentikAPI
 from kentik_api.public import QuerySQL, QuerySQLResult, QueryObject, QueryDataResult
 
-MappedQueryFn = Callable[..., Union[DataFrame, Dict[str, DataFrame]]]
+MappedQueryFn = Callable[..., DataFrame]
 
 
-@dataclass
+TIME_SERIES_FIELDS = ("timestamp", "value", "period")
+TIME_SERIES_REGEX = re.compile("__TS[.]([^.]+)[.]({})".format("|".join(TIME_SERIES_FIELDS)))
+
+
 class MappingEntry:
-    format: str
-    data_type: Optional[str]
-    is_index: bool = False
+    def __init__(self, source: str, data_type: Optional[str] = None, is_index: bool = False):
+        self.source = source
+        self.data_type = data_type
+        self.is_index = is_index
+        m = TIME_SERIES_REGEX.match(self.source)
+        if m is None:
+            self.time_series_name = None
+            self.time_series_field = None
+            self.time_series_field_idx = None
+        else:
+            self.time_series_name = m.group(1)
+            self.time_series_field = m.group(2)
+            self.time_series_field_idx = TIME_SERIES_FIELDS.index(self.time_series_field)
+            if self.time_series_field_idx == 0:
+                #  automatically set data_type for time series timestamps
+                if self.data_type is not None:
+                    logging.warning(
+                        "Overriding 'data_type: %s' for time_series timestamp (source: %s)", self.data_type, self.source
+                    )
+                self.data_type = "unix_timestamp_millis"
+
+    @property
+    def is_time_series_key(self) -> bool:
+        return self.time_series_field is not None
+
+
+def apply_data_types(df: DataFrame, mapping: Generator[Tuple[str, MappingEntry], None, None]) -> None:
+    """
+    Apply data types specified in the mapping to the DataFrame
+    :param df: DataFrame to operate on
+    :param mapping: mapping dictionary
+    :return: None (modified input DataFrame in place)
+    """
+    for k, m in mapping:
+        if m.data_type is not None:
+            if m.data_type == "time":
+                df[k] = to_datetime(df[k])
+            elif m.data_type == "unix_timestamp":
+                df[k] = to_datetime(df[k], unit="s", utc=True)
+            elif m.data_type == "unix_timestamp_millis":
+                df[k] = to_datetime(df[k] / 1000, unit="s", utc=True)
+            else:
+                df[k] = df[k].astype(m.data_type)
+        if m.is_index:
+            df.set_index(k, inplace=True)
+            df.sort_index(inplace=True)
 
 
 SQLResultMappingType = TypeVar("SQLResultMappingType", bound="SQLResultMapping")
@@ -34,7 +81,7 @@ class SQLResultMapping:
                 raise RuntimeError(f"Duplicate mapping for column '{c}' in query definition ({data})")
             if type(d) != dict or "source" not in d.keys():
                 raise RuntimeError(f"'source' is missing in query definition entry for column {c} ({data})")
-            mapping[c] = MappingEntry(format=d["source"], data_type=d.get("type"), is_index=d.get("index", False))
+            mapping[c] = MappingEntry(source=d["source"], data_type=d.get("type"), is_index=d.get("index", False))
         return mapping
 
     def __init__(self, entries: Optional[Dict[str, MappingEntry]] = None) -> None:
@@ -51,9 +98,14 @@ class SQLResultMapping:
     def has(self, column) -> bool:
         return column in self._entries
 
+    @property
     def items(self) -> Generator[Tuple[str, MappingEntry], None, None]:
         for k, v in self._entries.items():
             yield k, v
+
+    @property
+    def entries(self):
+        return self._entries
 
     @property
     def is_empty(self) -> bool:
@@ -115,21 +167,10 @@ def sql_result_to_df(mapping: SQLResultMapping, sql_data: QuerySQLResult) -> Opt
             for k, v in row:
                 data[k].append(v)
         else:
-            for k, m in mapping.items():
-                data[k].append(m.format.format(**row))
+            for k, m in mapping.items:
+                data[k].append(m.source.format(**row))
     df = DataFrame.from_dict(data)
-    for k, m in mapping.items():
-        if m.data_type is None:
-            continue
-        if m.data_type == "time":
-            df[k] = to_datetime(df[k])
-        elif m.data_type == "unix_timestamp":
-            df[k] = to_datetime(df[k], unit="s", utc=True)
-        else:
-            df[k] = df[k].astype(m.data_type)
-        if m.is_index:
-            df.set_index(k, inplace=True)
-            df.sort_index(inplace=True)
+    apply_data_types(df, mapping.items)
     logging.debug("df shape: (%d, %d)", df.shape[0], df.shape[1])
     return df
 
@@ -140,38 +181,75 @@ DataResultMappingType = TypeVar("DataResultMappingType", bound="DataResultMappin
 class DataResultMapping:
     @classmethod
     def from_dict(cls: Type[DataResultMappingType], data: Optional[Dict] = None) -> DataResultMappingType:
-        mapping = cls()
         if data is None:
-            return mapping
-        for c, d in data.items():
-            if mapping.has(c):
-                raise RuntimeError(f"Duplicate mapping for column '{c}' in query definition ({data})")
-            if type(d) != dict or "source" not in d.keys():
-                raise RuntimeError(f"'source' is missing in query definition entry for column {c} ({data})")
-            mapping[c] = MappingEntry(format=d["source"], data_type=d.get("type"), is_index=d.get("index", False))
-        return mapping
+            raise RuntimeError("No data passed to DataResultMapping.from_dict")
+        mappings: Dict[str, Dict[str, MappingEntry]] = dict()
+        for m in ("aggregates", "time_series"):
+            mappings[m] = dict()
+            if m not in data:
+                logging.debug("No %s in mapping data %s", m, data)
+                continue
+            for c, d in data[m].items():
+                if c in mappings[m]:
+                    raise RuntimeError(f"Duplicate mapping for column '{c}' in '{m}' mapping data ({data})")
+                if type(d) != dict or "source" not in d.keys():
+                    raise RuntimeError(f"'source' is missing in '{m}' mapping entry for column '{c}' ({data})")
+                mappings[m][c] = MappingEntry(
+                    source=d["source"], data_type=d.get("type"), is_index=d.get("index", False)
+                )
+        return cls(**mappings)
 
-    def __init__(self, entries: Optional[Dict[str, MappingEntry]] = None) -> None:
-        self._entries: Dict[str, MappingEntry] = dict()
-        if entries:
-            self._entries.update(entries)
+    def __init__(
+        self,
+        aggregates: Optional[Dict[str, MappingEntry]] = None,
+        time_series: Optional[Dict[str, MappingEntry]] = None,
+    ) -> None:
+        self._aggregates: Dict[str, MappingEntry] = dict()
+        self._time_series: Dict[str, MappingEntry] = dict()
+        if aggregates:
+            self._aggregates.update(aggregates)
+        if time_series:
+            self._time_series.update(time_series)
+            # sanity check that the mapping uses any fields from `timeSeries`
+            for _, m in self.time_series:
+                if m.is_time_series_key:
+                    break
+            else:
+                raise RuntimeError("'time_series' mapping must contain at least one '__TS' 'source'")
 
-    def __getitem__(self, column):
-        return self._entries.get(column)
+    def set_aggregates(self, key: str, value: MappingEntry) -> None:
+        self._aggregates[key] = value
 
-    def __setitem__(self, key: str, value: MappingEntry) -> None:
-        self._entries[key] = value
+    def set_time_series(self, key: str, value: MappingEntry) -> None:
+        self._time_series[key] = value
 
-    def has(self, column) -> bool:
-        return column in self._entries
+    def has_aggregates_column(self, column) -> bool:
+        return column in self._aggregates
 
-    def items(self) -> Generator[Tuple[str, MappingEntry], None, None]:
-        for k, v in self._entries.items():
+    def has_time_series_column(self, column) -> bool:
+        return column in self._time_series
+
+    @property
+    def aggregates(self) -> Generator[Tuple[str, MappingEntry], None, None]:
+        for k, v in self._aggregates.items():
             yield k, v
 
     @property
+    def time_series(self) -> Generator[Tuple[str, MappingEntry], None, None]:
+        for k, v in self._time_series.items():
+            yield k, v
+
+    @property
+    def has_aggregates(self):
+        return len(self._aggregates) > 0
+
+    @property
+    def has_time_series(self):
+        return len(self._time_series) > 0
+
+    @property
     def is_empty(self) -> bool:
-        return len(self._entries) == 0
+        return not self.has_aggregates and not self.has_time_series
 
 
 class DataQueryDefinition:
@@ -196,17 +274,17 @@ class DataQueryDefinition:
         self.mapping = mapping
 
     def expand_query(self, **kwargs) -> Dict:
-        def _expand_dict(data: Dict, parent: str, **kwargs) -> Dict:
-            return {k: _expand(v, parent=f"{parent}.{k}", **kwargs) for k, v in data.items()}
+        def _expand_dict(data: Dict, parent: str) -> Dict:
+            return {k: _expand(v, parent=f"{parent}.{k}") for k, v in data.items()}
 
-        def _expand_list(data: List, parent: str , **kwargs) -> List:
-            return [_expand(v, parent=f"{parent}[{i}]", **kwargs) for i, v in enumerate(data)]
+        def _expand_list(data: List, parent: str) -> List:
+            return [_expand(v, parent=f"{parent}[{i}]") for i, v in enumerate(data)]
 
-        def _expand(data: Any, parent: str, **kwargs) -> Any:
+        def _expand(data: Any, parent: str) -> Any:
             if type(data) == dict:
-                return _expand_dict(data, parent, **kwargs)
+                return _expand_dict(data, parent)
             elif type(data) == list:
-                return _expand_list(data, parent, **kwargs)
+                return _expand_list(data, parent)
             elif type(data) == str:
                 logging.debug("key: %s expanding: '%s'", f"{parent}", data)
                 r = data.format(**kwargs)
@@ -214,7 +292,8 @@ class DataQueryDefinition:
                 return r
             else:
                 return data
-        return _expand(self.query, parent="", **kwargs)
+
+        return _expand(self.query, parent="")
 
     def query_object(self, **kwargs) -> QueryObject:
         """
@@ -222,44 +301,93 @@ class DataQueryDefinition:
         """
         return QueryObject.from_dict(self.expand_query(**kwargs))
 
-    def get_data(self, api: KentikAPI, **kwargs) -> Dict[str, DataFrame]:
+    def get_data(self, api: KentikAPI, **kwargs) -> List[Tuple[Optional[DataFrame], Optional[DataFrame]]]:
         result = api.query.data(self.query_object(**kwargs))
         return data_result_to_df(self.mapping, result)
 
-    def make_query_fn(self, api: KentikAPI) -> MappedQueryFn:
-        """
-        Create a function returning DataFrame based on the query definition
-        The main purpose is to pass the function to the DFCache.fetch method
-        """
 
-        def data_mapped_query(**kwargs) -> Dict[str, DataFrame]:
-            return self.get_data(api, **kwargs)
-
-        return data_mapped_query
-
-
-def data_result_to_df(mapping: DataResultMapping, data: QueryDataResult) -> Dict[str, DataFrame]:
+def data_result_to_df(
+    mapping: DataResultMapping, data: QueryDataResult
+) -> List[Tuple[Optional[DataFrame], Optional[DataFrame]]]:
     """
-    Map KDE SQL query result to Pandas DataFrame
-    If no mapping is provided in query definition, every column in response row is included as DataFrame columns
-    otherwise data are mapped to DataFrame based on mapping entries
+    Map KDE API data query result to Pandas DataFrames. A Tuple of two DataFrames is created for each result returned.
+    In each tuple the first entry contains DataFrame for aggregates mapping, if present in mapping data, otherwise None.
+    The second entry contains DataFrame for time_series mapping, if present in the mapping data, otherwise None.
     """
     if len(data.results) < 1:
         logging.debug("No data in query result")
-        return None
+        return [(None, None)]
     if mapping.is_empty:
         logging.error("Empty mapping")
         raise RuntimeError("Mapping is required to transform data query results to DataFrames")
-    out = dict()
-    for r in data.results:
-        raise RuntimeError("Code is not finished")
-
-    # INSERT DATA MAPPING
-
-        columns = defaultdict(list)
-        df = DataFrame.from_dict(data)
-        apply_data_types(df, mapping)
-        logging.debug("df shape: (%d, %d)", df.shape[0], df.shape[1])
-        out[r.bucket] = df
+    out = list()
+    for i, r in enumerate(data.results):
+        aggregates = None
+        time_series = None
+        if mapping.has_aggregates:
+            out_data = dict()
+            for c, m in mapping.aggregates:
+                out_data[c] = [m.source.format(bucket=r["bucket"], **e) for e in r["data"]]
+            aggregates = DataFrame.from_dict(out_data)
+            apply_data_types(aggregates, mapping.aggregates)
+        if mapping.has_time_series:
+            # check that all data entries in the result have `timeSeries` key
+            missing = [e["key"] for e in r["data"] if "timeSeries" not in e or not e["timeSeries"]]
+            if missing:
+                logging.warning("%d data entries do not contain time series and will be ignored", len(missing))
+            if len(r["data"]) > 1:
+                # if there is more than one `data` entry, time_series mapping must contain at least one non-time series
+                # column to make rows unique
+                for _, m in mapping.time_series:
+                    if not m.is_time_series_key:
+                        break
+                else:
+                    raise RuntimeError(
+                        "More than 1 data item in result,"
+                        "'time_series' mapping must contain at least one non '__TS' 'source'"
+                    )
+            out_data = {k: list() for k, _ in mapping.time_series}
+            for e in r["data"]:
+                if e["key"] in missing:
+                    logging.debug("no time series in entry: %s", e)
+                    continue
+                # check that all time_series names are present
+                missing_ts = [
+                    n
+                    for n in [m.time_series_name for _, m in mapping.time_series if m.is_time_series_key]
+                    if n not in e["timeSeries"]
+                ]
+                if missing_ts:
+                    raise RuntimeError(
+                        "No 'timeSeries' for variables(s) '{mts}' in entry '{e}'".format(
+                            mts=",".join([str(x) for x in missing_ts]), e=e
+                        )
+                    )
+                ts_len = max(
+                    [
+                        len(e["timeSeries"][m.time_series_name]["flow"])
+                        for _, m in mapping.time_series
+                        if m.is_time_series_key
+                    ]
+                )
+                for k, m in mapping.time_series:
+                    if m.is_time_series_key:
+                        out_data[k].extend(
+                            row[m.time_series_field_idx] for row in e["timeSeries"][m.time_series_name]["flow"]
+                        )
+                    else:
+                        val = m.source.format(bucket=r["bucket"], **e)
+                        out_data[k].extend([val] * ts_len)
+            time_series = DataFrame.from_dict(out_data)
+            apply_data_types(time_series, mapping.time_series)
+            #  FINISH MAPPING OF TIME SERIES DATA
+        if aggregates is not None:
+            logging.debug("result[%d]: aggregates shape: (%d, %d)", i, aggregates.shape[0], aggregates.shape[1])
+        else:
+            logging.debug("result[%d]: no aggregates", i)
+        if time_series is not None:
+            logging.debug("result[%d]: time_series shape: (%d, %d)", i, time_series.shape[0], time_series.shape[1])
+        else:
+            logging.debug("result[%d]: no time_series", i)
+        out.append((aggregates, time_series))
     return out
-

--- a/kentik_api_library/kentik_api/public/__init__.py
+++ b/kentik_api_library/kentik_api/public/__init__.py
@@ -20,6 +20,7 @@ from .query_object import (
     MetricType,
     Query,
     QueryArrayItem,
+    QueryDataResult,
     QueryObject,
     TimeFormat,
 )

--- a/kentik_api_library/kentik_api/public/query_object.py
+++ b/kentik_api_library/kentik_api/public/query_object.py
@@ -148,6 +148,8 @@ class Aggregate:
     sample_rate: int = 1
     rank: Optional[int] = None  # valid: number 5..99; only used when fn == percentile
     raw: Optional[bool] = None  # required for topxchart queries
+    is_bytes: Optional[bool] = None
+    fix: Optional[int] = None
 
     @classmethod
     def from_dict(cls: Type[AggregateType], data: Dict) -> AggregateType:
@@ -161,7 +163,6 @@ class Aggregate:
         missing = [field_name for field_name in mandatory_dataclass_attributes(cls) if field_name not in data]
         if missing:
             raise RuntimeError(f"{cls.__name__}.from_dict: missing mandatory fields: {missing}")
-        # construct Filters, Dimension, Metric and SavedFilter arrays
         _d = dict()
         _d.update(data)
         _d["fn"] = AggregateFunctionType(data["fn"])
@@ -217,8 +218,11 @@ class Query:
     hideCidr: Optional[bool] = None
     hostname_lookup: bool = True
     isOverlay: Optional[dict] = None
-    lookback_seconds: Optional[int] = None  # value != 0 overrides "starting_time" and "ending_time"
+    # "lookback_seconds" MUST be present and set to 0 in order for "starting_time" and "ending_time" to be honored
+    # It defaults to 3600 seconds if absent and overrides "(starting|ending)_time"
+    lookback_seconds: Optional[int] = 0
     matrixBy: List[str] = field(default_factory=list)  # DimensionType or custom dimension
+    minsPolling: Optional[int] = None
     mirror: Optional[dict] = None
     mirrorUnits: Optional[dict] = None
     outsort: str = ""  # name of aggregate object, required when more than 1 objects on "aggregates" list

--- a/kentik_api_library/kentik_api/public/query_object.py
+++ b/kentik_api_library/kentik_api/public/query_object.py
@@ -156,7 +156,7 @@ class Aggregate:
         """
         Construct Aggregate object based on data in a dictionary. The dictionary must provide values for all mandatory
         Query attributes
-        :param data: dictionary
+        :param data: dictionary containing class attributes
         :return: instance of Aggregate
         """
         # verify that values are provided for all mandatory fields

--- a/kentik_api_library/kentik_api/public/query_object.py
+++ b/kentik_api_library/kentik_api/public/query_object.py
@@ -149,6 +149,7 @@ class Aggregate:
     rank: Optional[int] = None  # valid: number 5..99; only used when fn == percentile
     raw: Optional[bool] = None  # required for topxchart queries
     is_bytes: Optional[bool] = None
+    is_count: Optional[bool] = None
     fix: Optional[int] = None
 
     @classmethod


### PR DESCRIPTION
This PR adds support for mapping data retrieved with `topXdata` query to pandas DataFrames.
This functionality is provided by the `DataQueryDefinition` class.