### PR TITLE
Add support for storing proxy and URL in profile

### DIFF
--- a/kentik_api_library/kentik_api/utils/__init__.py
+++ b/kentik_api_library/kentik_api/utils/__init__.py
@@ -1,3 +1,3 @@
-from .auth import get_credentials
+from .auth import get_credentials, get_url, get_proxy
 from .device_cache import DeviceCache
 from .time_sequence import time_seq

--- a/kentik_api_library/kentik_api/utils/auth.py
+++ b/kentik_api_library/kentik_api/utils/auth.py
@@ -1,37 +1,55 @@
 import json
 import logging
 import os
+from functools import cache
 from typing import Dict, Optional, Tuple
 
+log = logging.getLogger("auth")
 
-def load_credential_profile(filename: str) -> Optional[Dict]:
+
+@cache
+def load_credential_profile(profile: str) -> Dict:
+    home: str = os.environ.get("KTAPI_HOME", os.environ.get("HOME", "."))
+    filename = os.environ.get("KTAPI_CFG_FILE", os.path.join(home, ".kentik", profile))
     try:
         with open(filename) as f:
-            cfg = json.load(f)
+            try:
+                cfg = json.load(f)
+            except json.decoder.JSONDecodeError as ex:
+                log.critical("Failed to parse JSON in profile file '%s' (exception: %s)", filename, ex)
+                return {}
     except OSError as e:
-        logging.critical("Cannot open config file: %s (%s)", filename, str(e))
-        return None
+        log.critical("Cannot open config file: %s (%s)", filename, str(e))
+        return {}
     ok: bool = True
+    # check for required keys
     for key in ("email", "api-key"):
         if key not in cfg:
-            logging.critical("No '%s' in config file: %s", key, filename)
+            log.critical("No '%s' in config file: %s", key, filename)
             ok = False
     if ok:
         return cfg
     else:
-        return None
+        return {}
 
 
 def get_credentials(profile: str = "default") -> Tuple[str, str]:
     email = os.environ.get("KTAPI_AUTH_EMAIL")
     token = os.environ.get("KTAPI_AUTH_TOKEN")
-    home: str = os.environ.get("KTAPI_HOME", os.environ.get("HOME", "."))
     if email is None or token is None:
-        cfg = load_credential_profile(os.environ.get("KTAPI_CFG_FILE", os.path.join(home, ".kentik", profile)))
-        if cfg is not None:
+        cfg = load_credential_profile(profile)
+        if cfg:
             email = cfg["email"]
             token = cfg["api-key"]
     if email and token:
         return email, token
     else:
         raise RuntimeError("Failed to get API authentication credentials")
+
+
+def get_url(profile: str = "default") -> Optional[str]:
+    return os.environ.get("KTAPI_URL", load_credential_profile(profile).get("url"))
+
+
+def get_proxy(profile: str = "default") -> Optional[str]:
+    return os.environ.get("KTAPI_PROXY", load_credential_profile(profile).get("proxy"))


### PR DESCRIPTION
Functions `get_url(<profile>`) and `get_proxy(<profile>)` has been added to `kentik_api.utils.auth`
The `load_credentials_profile` function has been refactored to cache results and resolve path to credentials file
The `get_credentials` function has been refactored to just pass profile name to `load_credentails_file`