### PR TITLE
Fix deserialization of Alarms and HistoricAlerts

### DIFF
--- a/kentik_api_library/kentik_api/api_resources/alerting_api.py
+++ b/kentik_api_library/kentik_api/api_resources/alerting_api.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List
 
 from kentik_api.api_calls import alerts
 from kentik_api.api_resources.base_api import BaseAPI
 from kentik_api.public.manual_mitigation import Alarm, AlertFilter, HistoricalAlert, ManualMitigation, SortOrder
 from kentik_api.requests_payload import manual_mitigations_payload
-from kentik_api.requests_payload.conversions import convert, enum_to_str
+from kentik_api.requests_payload.conversions import enum_to_str
 
 
 class AlertingAPI(BaseAPI):
@@ -31,13 +31,9 @@ class AlertingAPI(BaseAPI):
         if filter_by == AlertFilter.NONE and filter_val != "":
             raise ValueError("For filter_by == None, filter_val should be empty")
 
-        date_to_str = lambda date: date.strftime("%Y-%m-%dT%H:%M:%S")
-        start_time_str = convert(start_time, date_to_str)
-        end_time_str = convert(end_time, date_to_str)
-
         api_call = alerts.get_active_alerts(
-            start_time=start_time_str,
-            end_time=end_time_str,
+            start_time=start_time.isoformat(),
+            end_time=end_time.isoformat(),
             filter_by=enum_to_str(filter_by),
             filter_val=filter_val,
             show_mitigations=1 if show_mitigations else 0,
@@ -64,13 +60,9 @@ class AlertingAPI(BaseAPI):
         if filter_by == AlertFilter.NONE and filter_val != "":
             raise ValueError("For filter_by == None, filter_val should be empty")
 
-        date_to_str = lambda date: date.strftime("%Y-%m-%dT%H:%M:%S")
-        start_time_str = convert(start_time, date_to_str)
-        end_time_str = convert(end_time, date_to_str)
-
         api_call = alerts.get_alerts_history(
-            start_time=start_time_str,
-            end_time=end_time_str,
+            start_time=start_time.isoformat(),
+            end_time=end_time.isoformat(),
             filter_by=enum_to_str(filter_by),
             filter_val=filter_val,
             sort_order=enum_to_str(sort_order),

--- a/kentik_api_library/kentik_api/api_resources/alerting_api.py
+++ b/kentik_api_library/kentik_api/api_resources/alerting_api.py
@@ -5,7 +5,7 @@ from kentik_api.api_calls import alerts
 from kentik_api.api_resources.base_api import BaseAPI
 from kentik_api.public.manual_mitigation import Alarm, AlertFilter, HistoricalAlert, ManualMitigation, SortOrder
 from kentik_api.requests_payload import manual_mitigations_payload
-from kentik_api.requests_payload.conversions import convert, convert_or_none, enum_to_str
+from kentik_api.requests_payload.conversions import convert, enum_to_str
 
 
 class AlertingAPI(BaseAPI):

--- a/kentik_api_library/kentik_api/api_resources/alerting_api.py
+++ b/kentik_api_library/kentik_api/api_resources/alerting_api.py
@@ -8,7 +8,6 @@ from kentik_api.public.manual_mitigation import Alarm, AlertFilter, HistoricalAl
 from kentik_api.requests_payload import manual_mitigations_payload
 from kentik_api.requests_payload.conversions import enum_to_str
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kentik_api_library/kentik_api/public/manual_mitigation.py
+++ b/kentik_api_library/kentik_api/public/manual_mitigation.py
@@ -20,7 +20,7 @@ class Alarm:
     alarm_state: str
     alert_id: int
     mitigation_id: Optional[int]
-    threshold_id: int
+    threshold_id: Optional[int]
     alert_key: str
     alert_dimension: str
     alert_metric: List[str]
@@ -28,7 +28,7 @@ class Alarm:
     alert_value2nd: float
     alert_value3rd: float
     alert_match_count: int
-    alert_baseline: int
+    alert_baseline: float
     alert_severity: str
     baseline_used: int
     learning_mode: bool
@@ -41,7 +41,7 @@ class Alarm:
     mit_threshold_id: int
     args: str
     id: int
-    policy_id: int
+    policy_id: Optional[int]
     policy_name: str
     alert_key_lookup: str
 
@@ -54,16 +54,16 @@ class HistoricalAlert:
     alert_match_count: str
     alert_severity: str
     alert_id: int
-    threshold_id: int
+    threshold_id: Optional[int]
     alarm_id: int
     alert_key: str
     alert_dimension: str
     alert_metric: List[str]
     alert_value: float
-    alert_value2nd: int
-    alert_value3rd: int
-    alert_baseline: int
-    baseline_used: int
+    alert_value2nd: float
+    alert_value3rd: float
+    alert_baseline: float
+    baseline_used: float
     learning_mode: bool
     debug_mode: bool
     creation_time: datetime

--- a/kentik_api_library/tests/unit/api_resources/test_alerting.py
+++ b/kentik_api_library/tests/unit/api_resources/test_alerting.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from http import HTTPStatus
 
 from kentik_api.api_calls.api_call import APICallMethods
@@ -132,7 +132,7 @@ def test_get_active_alerts_with_filter() -> None:
 
     assert len(alarms) == 1
     assert alarms[0].alarm_id == 82867908
-    assert alarms[0].alarm_start == datetime(2021, 1, 19, 13, 50, 0, 0)
+    assert alarms[0].alarm_start == datetime(2021, 1, 19, 13, 50, 0, 0, tzinfo=timezone.utc)
     assert alarms[0].alarm_end is None
 
 
@@ -157,7 +157,7 @@ def test_get_active_alerts_without_filter() -> None:
 
     assert len(alarms) == 1
     assert alarms[0].alarm_id == 82867908
-    assert alarms[0].alarm_start == datetime(2021, 1, 19, 13, 50, 0, 0)
+    assert alarms[0].alarm_start == datetime(2021, 1, 19, 13, 50, 0, 0, tzinfo=timezone.utc)
     assert alarms[0].alarm_end is None
 
 
@@ -185,7 +185,7 @@ def test_get_alerts_history_with_sort_and_filter() -> None:
 
     assert len(alerts) == 1
     assert alerts[0].alarm_id == 82867908
-    assert alerts[0].alarm_start_time == datetime(2021, 1, 19, 13, 50, 0, 0)
+    assert alerts[0].alarm_start_time == datetime(2021, 1, 19, 13, 50, 0, 0, tzinfo=timezone.utc)
 
 
 def test_get_alerts_history_without_sort_and_filter() -> None:
@@ -209,4 +209,4 @@ def test_get_alerts_history_without_sort_and_filter() -> None:
 
     assert len(alerts) == 1
     assert alerts[0].alarm_id == 82867908
-    assert alerts[0].alarm_start_time == datetime(2021, 1, 19, 13, 50, 0, 0)
+    assert alerts[0].alarm_start_time == datetime(2021, 1, 19, 13, 50, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
Details:
1) make all variables related to "baseline" and "alert_value" floats
2) make conversion of timestamps straight-forward avoiding unnecessary use of the `convert` function and make all of them be explicitly in the UTC timezone
3) ignore Alarm entries containing `type` attribute, because those do not seem to conform to the general schema

The last change is an ugly temporary hack. I have question regarding "non-conformant" entries pending with the subject domain expert.