### PR TITLE
Fix package versioning to reflect tags again

### DIFF
--- a/kentik_api_library/pyproject.toml
+++ b/kentik_api_library/pyproject.toml
@@ -2,6 +2,10 @@
 requires = ["setuptools", "wheel", "setuptools_scm", "gitpython"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+root = ".."
+relative_to = "."
+
 [tool.black]
 line-length = 120
 target-version = ['py39']


### PR DESCRIPTION
Switch tot using `pyproject.toml` (58ec40020f47d459c3931764ad4bdcd2a5ff592b) made setuptools_scm unable to find `.git` directory which resulted in all
packages having version 0.0.0.