### PR TITLE
Assorted fixes to synthetics API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 cython_debug/
 
 .vscode/
+.idea/

--- a/kentik_api_library/kentik_api/kentik_api.py
+++ b/kentik_api_library/kentik_api/kentik_api.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, List, Optional, Tuple, Union
 
 from .api_connection.api_connector import APIConnector
@@ -35,6 +36,9 @@ class KentikAPI:
         proxy: Optional[str] = None,
         grpc_client_options: Optional[List[Tuple[str, Any]]] = None,
     ) -> None:
+        if not api_host:
+            logging.debug("KentikAPI: null api_host, setting to %s", self.API_HOST_US)
+            api_host = self.API_HOST_US
         api_v5_url = self.make_api_v5_url(api_host)
         connector = APIConnector(api_v5_url, auth_email, auth_token, timeout, retry_strategy, proxy)
         self.device_labels = DeviceLabelsAPI(connector)

--- a/kentik_api_library/setup.py
+++ b/kentik_api_library/setup.py
@@ -222,7 +222,8 @@ class FetchGRPCCode(Command):
         dst.mkdir(parents=True)
         # checkout source repo and copy stubs
         with TemporaryDirectory() as tmp:
-            git.Repo.clone_from(self.repo, tmp)
+            repo = git.Repo.clone_from(self.repo, tmp)
+            repo.create_head("OK", "896729e59945404959e930f63f7a8965c109537d").checkout()
             Path(tmp).joinpath(self.src_path).rename(dst)
 
 

--- a/kentik_api_library/tests/e2e/synthetics/test_agent.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_agent.py
@@ -7,66 +7,44 @@ from kentik_api.synthetics.synth_tests.agent import AgentTestSettings, AgentTest
 from kentik_api.synthetics.synth_tests.base import PingTask, TraceTask
 from kentik_api.synthetics.types import IPFamily, Protocol, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_agent_test_crud() -> None:
     agents = pick_agent_ids(count=4)
-    settings1 = AgentTestSettings(
+    initial_settings = AgentTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=[agents[0]],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         ping=PingTask(timeout=3000, count=5, delay=200, protocol=Protocol.ICMP),
         trace=TraceTask(timeout=22500, count=3, limit=30, delay=20, protocol=Protocol.UDP, port=3343),
         agent=AgentTestSpecific(target=agents[1], use_local_ip=False),
     )
-    settings2 = deepcopy(settings1)
-    settings2.family = IPFamily.V6
-    # settings2.period = 120  # period update doesn't take effect
-    settings2.agent_ids = [agents[2]]
-    settings2.health_settings = HEALTH2
-    settings2.ping.timeout = 4000
-    settings2.ping.count = 6
-    settings2.ping.delay = 300
-    settings2.trace.timeout = 22750
-    settings2.trace.count = 4
-    settings2.trace.limit = 40
-    settings2.trace.delay = 30
-    settings2.trace.protocol = Protocol.ICMP
-    settings2.agent.target = agents[3]
-    settings2.agent.use_local_ip = True
+    update_settings = deepcopy(initial_settings)
+    update_settings.family = IPFamily.V6
+    # update_settings.period = 120  # period update doesn't take effect
+    update_settings.agent_ids = [agents[2]]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    update_settings.ping.timeout = 4000
+    update_settings.ping.count = 6
+    update_settings.ping.delay = 300
+    update_settings.trace.timeout = 22750
+    update_settings.trace.count = 4
+    update_settings.trace.limit = 40
+    update_settings.trace.delay = 30
+    update_settings.trace.protocol = Protocol.ICMP
+    update_settings.agent.target = agents[3]
+    update_settings.agent.use_local_ip = True
+    test = AgentTest(make_e2e_test_name(TestType.AGENT), TestStatus.ACTIVE, initial_settings)
 
-    try:
-        # create
-        test = AgentTest("e2e-agent-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, AgentTest)
-        assert created_test.name == "e2e-agent-test"
-        assert created_test.type == TestType.AGENT
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
-
-        # set status and read
-        client().synthetics.set_test_status(created_test.id, TestStatus.PAUSED)
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, AgentTest)
-        assert received_test.name == "e2e-agent-test"
-        assert received_test.type == TestType.AGENT
-        assert received_test.status == TestStatus.PAUSED
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-agent-test-updated"
-        created_test.status = TestStatus.ACTIVE
-        created_test.settings = settings2
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, AgentTest)
-        assert updated_test.name == "e2e-agent-test-updated"
-        assert updated_test.type == TestType.AGENT
-        assert updated_test.status == TestStatus.ACTIVE
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings, pause_after_creation=True)

--- a/kentik_api_library/tests/e2e/synthetics/test_dns.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_dns.py
@@ -6,17 +6,25 @@ from kentik_api.synthetics.synth_tests import DNSTest
 from kentik_api.synthetics.synth_tests.dns import DNSTestSettings, DNSTestSpecific
 from kentik_api.synthetics.types import DNSRecordType, IPFamily, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_dns_crud() -> None:
     agents = pick_agent_ids(count=2)
-    settings1 = DNSTestSettings(
+    initial_settings = DNSTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=[agents[0]],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         dns=DNSTestSpecific(
             target="www.example.com",
             record_type=DNSRecordType.AAAA,
@@ -24,44 +32,16 @@ def test_dns_crud() -> None:
             port=53,
         ),
     )
-    settings2 = deepcopy(settings1)
-    # settings2.family = IPFamily.V6  # family update doesn't take effect
-    settings2.period = 120
-    settings2.agent_ids = [agents[1]]
-    settings2.health_settings = HEALTH2
-    # settings2.dns.target="www.wikipedia.org"  # target can't be updated after a test has been created
-    settings2.dns.record_type = DNSRecordType.A
-    settings2.dns.servers = ["8.8.8.8", "9.9.9.9"]
-    settings2.dns.port = 63
+    update_settings = deepcopy(initial_settings)
+    # update_settings.family = IPFamily.V6  # family update doesn't take effect
+    update_settings.period = 120
+    update_settings.agent_ids = [agents[1]]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    # update_settings.dns.target="www.wikipedia.org"  # target can't be updated after a test has been created
+    update_settings.dns.record_type = DNSRecordType.A
+    update_settings.dns.servers = ["8.8.8.8", "9.9.9.9"]
+    update_settings.dns.port = 63
 
-    try:
-        # create
-        test = DNSTest("e2e-dns-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, DNSTest)
-        assert created_test.name == "e2e-dns-test"
-        assert created_test.type == TestType.DNS
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
+    test = DNSTest(make_e2e_test_name(TestType.DNS), TestStatus.ACTIVE, initial_settings)
 
-        # read
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, DNSTest)
-        assert received_test.name == "e2e-dns-test"
-        assert received_test.type == TestType.DNS
-        assert received_test.status == TestStatus.ACTIVE
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-dns-test-updated"
-        created_test.settings = settings2
-        created_test.status = TestStatus.PAUSED  # to safely update DNS port to arbitrary value
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, DNSTest)
-        assert updated_test.name == "e2e-dns-test-updated"
-        assert updated_test.type == TestType.DNS
-        assert updated_test.status == TestStatus.PAUSED
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_dns_grid.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_dns_grid.py
@@ -6,17 +6,25 @@ from kentik_api.synthetics.synth_tests import DNSGridTest
 from kentik_api.synthetics.synth_tests.dns_grid import DNSGridTestSettings, DSNGridTestSpecific
 from kentik_api.synthetics.types import DNSRecordType, IPFamily, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_dns_grid_crud() -> None:
     agents = pick_agent_ids(count=2)
-    settings1 = DNSGridTestSettings(
+    initial_settings = DNSGridTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=[agents[0]],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         dns_grid=DSNGridTestSpecific(
             target="www.example.com",
             record_type=DNSRecordType.AAAA,
@@ -24,44 +32,16 @@ def test_dns_grid_crud() -> None:
             port=53,
         ),
     )
-    settings2 = deepcopy(settings1)
-    # settings2.family = IPFamily.V6  # family update doesn't take effect
-    settings2.period = 120
-    settings2.agent_ids = [agents[1]]
-    settings2.health_settings = HEALTH2
-    # settings2.dns_grid.target="www.wikipedia.org"  # target can't be updated after a test has been created
-    settings2.dns_grid.record_type = DNSRecordType.A
-    settings2.dns_grid.servers = ["8.8.8.8", "9.9.9.9"]
-    settings2.dns_grid.port = 63
+    update_settings = deepcopy(initial_settings)
+    # update_settings.family = IPFamily.V6  # family update doesn't take effect
+    update_settings.period = 120
+    update_settings.agent_ids = [agents[1]]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    # update_settings.dns_grid.target="www.wikipedia.org"  # target can't be updated after a test has been created
+    update_settings.dns_grid.record_type = DNSRecordType.A
+    update_settings.dns_grid.servers = ["8.8.8.8", "9.9.9.9"]
+    update_settings.dns_grid.port = 63
 
-    try:
-        # create
-        test = DNSGridTest("e2e-dnsgrid-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, DNSGridTest)
-        assert created_test.name == "e2e-dnsgrid-test"
-        assert created_test.type == TestType.DNS_GRID
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
+    test = DNSGridTest(make_e2e_test_name(TestType.DNS_GRID), TestStatus.ACTIVE, initial_settings)
 
-        # read
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, DNSGridTest)
-        assert received_test.name == "e2e-dnsgrid-test"
-        assert received_test.type == TestType.DNS_GRID
-        assert received_test.status == TestStatus.ACTIVE
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-dnsgrid-test-updated"
-        created_test.settings = settings2
-        created_test.status = TestStatus.PAUSED  # to safely update DNS port to arbitrary value
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, DNSGridTest)
-        assert updated_test.name == "e2e-dnsgrid-test-updated"
-        assert updated_test.type == TestType.DNS_GRID
-        assert updated_test.status == TestStatus.PAUSED
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_hostname.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_hostname.py
@@ -7,63 +7,44 @@ from kentik_api.synthetics.synth_tests.base import PingTask, TraceTask
 from kentik_api.synthetics.synth_tests.hostname import HostnameTestSettings, HostnameTestSpecific
 from kentik_api.synthetics.types import IPFamily, Protocol, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_hostname_crud() -> None:
     agents = pick_agent_ids(count=2)
-    settings1 = HostnameTestSettings(
+    initial_settings = HostnameTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=[agents[0]],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         ping=PingTask(timeout=3000, count=5, delay=200, protocol=Protocol.ICMP),
         trace=TraceTask(timeout=22500, count=3, limit=30, delay=20, protocol=Protocol.UDP, port=3343),
         hostname=HostnameTestSpecific(target="www.example.com"),
     )
-    settings2 = deepcopy(settings1)
-    settings2.family = IPFamily.V6
-    # settings2.period = 120  # period update doesn't take effect
-    settings2.agent_ids = [agents[1]]
-    settings2.health_settings = HEALTH2
-    settings2.ping.timeout = 4000
-    settings2.ping.count = 6
-    settings2.ping.delay = 300
-    settings2.trace.timeout = 22750
-    settings2.trace.count = 4
-    settings2.trace.limit = 40
-    settings2.trace.delay = 30
-    settings2.trace.protocol = Protocol.ICMP
-    # settings2.hostname.target="www.wikipedia.org"  # target can't be updated after test's been created
+    update_settings = deepcopy(initial_settings)
+    update_settings.family = IPFamily.V6
+    # update_settings.period = 120  # period update doesn't take effect
+    update_settings.agent_ids = [agents[1]]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    update_settings.ping.timeout = 4000
+    update_settings.ping.count = 6
+    update_settings.ping.delay = 300
+    update_settings.trace.timeout = 22750
+    update_settings.trace.count = 4
+    update_settings.trace.limit = 40
+    update_settings.trace.delay = 30
+    update_settings.trace.protocol = Protocol.ICMP
+    # update_settings.hostname.target="www.wikipedia.org"  # target can't be updated after test's been created
 
-    try:
-        # create
-        test = HostnameTest("e2e-hostname-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, HostnameTest)
-        assert created_test.name == "e2e-hostname-test"
-        assert created_test.type == TestType.HOSTNAME
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
+    test = HostnameTest(make_e2e_test_name(TestType.HOSTNAME), TestStatus.ACTIVE, initial_settings)
 
-        # read
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, HostnameTest)
-        assert received_test.name == "e2e-hostname-test"
-        assert received_test.type == TestType.HOSTNAME
-        assert received_test.status == TestStatus.ACTIVE
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-hostname-test-updated"
-        created_test.settings = settings2
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, HostnameTest)
-        assert updated_test.name == "e2e-hostname-test-updated"
-        assert updated_test.type == TestType.HOSTNAME
-        assert updated_test.status == TestStatus.ACTIVE
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_ip.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_ip.py
@@ -8,63 +8,44 @@ from kentik_api.synthetics.synth_tests.base import PingTask, TraceTask
 from kentik_api.synthetics.synth_tests.ip import IPTestSettings, IPTestSpecific
 from kentik_api.synthetics.types import IPFamily, Protocol, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_ip_crud() -> None:
     agents = pick_agent_ids(count=2)
-    settings1 = IPTestSettings(
+    initial_settings = IPTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=[agents[0]],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         ping=PingTask(timeout=3000, count=5, delay=200, protocol=Protocol.ICMP),
         trace=TraceTask(timeout=22500, count=3, limit=30, delay=20, protocol=Protocol.UDP, port=3343),
         ip=IPTestSpecific(targets=[IP("54.161.222.85"), IP("34.205.242.146")]),
     )
-    settings2 = deepcopy(settings1)
-    settings2.family = IPFamily.V6
-    # settings2.period = 120  # period update doesn't take effect
-    settings2.agent_ids = [agents[1]]
-    settings2.health_settings = HEALTH2
-    settings2.ping.timeout = 4000
-    settings2.ping.count = 6
-    settings2.ping.delay = 300
-    settings2.trace.timeout = 22750
-    settings2.trace.count = 4
-    settings2.trace.limit = 40
-    settings2.trace.delay = 30
-    settings2.trace.protocol = Protocol.ICMP
-    # settings2.ip.targets = [IP("55.161.222.85"), IP("35.205.242.146")]  # can't update after created test's been created
+    update_settings = deepcopy(initial_settings)
+    update_settings.family = IPFamily.V6
+    # update_settings.period = 120  # period update doesn't take effect
+    update_settings.agent_ids = [agents[1]]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    update_settings.ping.timeout = 4000
+    update_settings.ping.count = 6
+    update_settings.ping.delay = 300
+    update_settings.trace.timeout = 22750
+    update_settings.trace.count = 4
+    update_settings.trace.limit = 40
+    update_settings.trace.delay = 30
+    update_settings.trace.protocol = Protocol.ICMP
+    # update_settings.ip.targets = [IP("55.161.222.85"), IP("35.205.242.146")]  # can't update after creation
 
-    try:
-        # create
-        test = IPTest("e2e-ip-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, IPTest)
-        assert created_test.name == "e2e-ip-test"
-        assert created_test.type == TestType.IP
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
+    test = IPTest(make_e2e_test_name(TestType.IP), TestStatus.ACTIVE, initial_settings)
 
-        # read
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, IPTest)
-        assert received_test.name == "e2e-ip-test"
-        assert received_test.type == TestType.IP
-        assert received_test.status == TestStatus.ACTIVE
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-ip-test-updated"
-        created_test.settings = settings2
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, IPTest)
-        assert updated_test.name == "e2e-ip-test-updated"
-        assert updated_test.type == TestType.IP
-        assert updated_test.status == TestStatus.ACTIVE
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_network_grid.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_network_grid.py
@@ -8,63 +8,44 @@ from kentik_api.synthetics.synth_tests.base import PingTask, TraceTask
 from kentik_api.synthetics.synth_tests.network_grid import GridTestSettings, NetworkGridTestSpecific
 from kentik_api.synthetics.types import IPFamily, Protocol, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_network_grid_crud() -> None:
     agents = pick_agent_ids(count=2)
-    settings1 = GridTestSettings(
+    initial_settings = GridTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=[agents[0]],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         ping=PingTask(timeout=3000, count=5, delay=200, protocol=Protocol.ICMP),
         trace=TraceTask(timeout=22500, count=3, limit=30, delay=20, protocol=Protocol.UDP, port=3343),
         network_grid=NetworkGridTestSpecific(targets=[IP("54.161.222.85"), IP("34.205.242.146")]),
     )
-    settings2 = deepcopy(settings1)
-    settings2.family = IPFamily.V6
-    # settings2.period = 120  # period update doesn't take effect
-    settings2.agent_ids = [agents[1]]
-    settings2.health_settings = HEALTH2
-    settings2.ping.timeout = 4000
-    settings2.ping.count = 6
-    settings2.ping.delay = 300
-    settings2.trace.timeout = 22750
-    settings2.trace.count = 4
-    settings2.trace.limit = 40
-    settings2.trace.delay = 30
-    settings2.trace.protocol = Protocol.ICMP
-    settings2.network_grid.targets = [IP("77.126.243.32"), IP("44.211.231.198")]
+    update_settings = deepcopy(initial_settings)
+    update_settings.family = IPFamily.V6
+    # update_settings.period = 120  # period update doesn't take effect
+    update_settings.agent_ids = [agents[1]]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    update_settings.ping.timeout = 4000
+    update_settings.ping.count = 6
+    update_settings.ping.delay = 300
+    update_settings.trace.timeout = 22750
+    update_settings.trace.count = 4
+    update_settings.trace.limit = 40
+    update_settings.trace.delay = 30
+    update_settings.trace.protocol = Protocol.ICMP
+    update_settings.network_grid.targets = [IP("77.126.243.32"), IP("44.211.231.198")]
 
-    try:
-        # create
-        test = NetworkGridTest("e2e-networkgrid-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, NetworkGridTest)
-        assert created_test.name == "e2e-networkgrid-test"
-        assert created_test.type == TestType.NETWORK_GRID
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
+    test = NetworkGridTest(make_e2e_test_name(TestType.NETWORK_GRID), TestStatus.ACTIVE, initial_settings)
 
-        # read
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, NetworkGridTest)
-        assert received_test.name == "e2e-networkgrid-test"
-        assert received_test.type == TestType.NETWORK_GRID
-        assert received_test.status == TestStatus.ACTIVE
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-networkgrid-test-updated"
-        created_test.settings = settings2
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, NetworkGridTest)
-        assert updated_test.name == "e2e-networkgrid-test-updated"
-        assert updated_test.type == TestType.NETWORK_GRID
-        assert updated_test.status == TestStatus.ACTIVE
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_network_mesh.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_network_mesh.py
@@ -7,63 +7,44 @@ from kentik_api.synthetics.synth_tests.base import PingTask, TraceTask
 from kentik_api.synthetics.synth_tests.network_mesh import NetworkMeshTestSettings, NetworkMeshTestSpecific
 from kentik_api.synthetics.types import IPFamily, Protocol, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_network_mesh_crud() -> None:
     agents = pick_agent_ids(count=4)
-    settings1 = NetworkMeshTestSettings(
+    initial_settings = NetworkMeshTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=agents[0:2],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         ping=PingTask(timeout=3000, count=5, delay=200, protocol=Protocol.ICMP),
         trace=TraceTask(timeout=22500, count=3, limit=30, delay=20, protocol=Protocol.UDP, port=3343),
         network_mesh=NetworkMeshTestSpecific(use_local_ip=True),
     )
-    settings2 = deepcopy(settings1)
-    settings2.family = IPFamily.V6
-    # settings2.period = 120  # period update doesn't take effect
-    settings2.agent_ids = agents[2:4]
-    settings2.health_settings = HEALTH2
-    settings2.ping.timeout = 4000
-    settings2.ping.count = 6
-    settings2.ping.delay = 300
-    settings2.trace.timeout = 22750
-    settings2.trace.count = 4
-    settings2.trace.limit = 40
-    settings2.trace.delay = 30
-    settings2.trace.protocol = Protocol.ICMP
-    # settings2.network_mesh.use_local_ip=False  # can't be updated after a test's been created
+    update_settings = deepcopy(initial_settings)
+    update_settings.family = IPFamily.V6
+    # update_settings.period = 120  # period update doesn't take effect
+    update_settings.agent_ids = agents[2:4]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    update_settings.ping.timeout = 4000
+    update_settings.ping.count = 6
+    update_settings.ping.delay = 300
+    update_settings.trace.timeout = 22750
+    update_settings.trace.count = 4
+    update_settings.trace.limit = 40
+    update_settings.trace.delay = 30
+    update_settings.trace.protocol = Protocol.ICMP
+    # update_settings.network_mesh.use_local_ip=False  # can't be updated after a test's been created
 
-    try:
-        # create
-        test = NetworkMeshTest("e2e-networkmesh-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, NetworkMeshTest)
-        assert created_test.name == "e2e-networkmesh-test"
-        assert created_test.type == TestType.NETWORK_MESH
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
+    test = NetworkMeshTest(make_e2e_test_name(TestType.NETWORK_MESH), TestStatus.ACTIVE, initial_settings)
 
-        # read
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, NetworkMeshTest)
-        assert received_test.name == "e2e-networkmesh-test"
-        assert received_test.type == TestType.NETWORK_MESH
-        assert received_test.status == TestStatus.ACTIVE
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-networkmesh-test-updated"
-        created_test.settings = settings2
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, NetworkMeshTest)
-        assert updated_test.name == "e2e-networkmesh-test-updated"
-        assert updated_test.type == TestType.NETWORK_MESH
-        assert updated_test.status == TestStatus.ACTIVE
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_page_load.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_page_load.py
@@ -7,17 +7,25 @@ from kentik_api.synthetics.synth_tests.base import PingTask, TraceTask
 from kentik_api.synthetics.synth_tests.page_load import PageLoadTestSettings, PageLoadTestSpecific
 from kentik_api.synthetics.types import IPFamily, Protocol, TaskType, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_page_load_crud() -> None:
     agents = pick_agent_ids(count=2, page_load_support=True)
-    settings1 = PageLoadTestSettings(
+    initial_settings = PageLoadTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=[agents[0]],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         tasks=[TaskType.PING, TaskType.TRACE_ROUTE, TaskType.PAGE_LOAD],
         ping=PingTask(timeout=3000, count=5, delay=200, protocol=Protocol.ICMP),
         trace=TraceTask(timeout=22500, count=3, limit=30, delay=20, protocol=Protocol.UDP, port=3343),
@@ -29,53 +37,26 @@ def test_page_load_crud() -> None:
             css_selectors={"id": "#id", "class": ".class"},
         ),
     )
-    settings2 = deepcopy(settings1)
-    settings2.family = IPFamily.V6
-    settings2.period = 120
-    settings2.agent_ids = [agents[1]]
-    settings2.health_settings = HEALTH2
-    settings2.tasks = [TaskType.PING, TaskType.TRACE_ROUTE, TaskType.PAGE_LOAD]
-    settings2.ping.timeout = 4000
-    settings2.ping.count = 6
-    settings2.ping.delay = 300
-    settings2.trace.timeout = 22750
-    settings2.trace.count = 4
-    settings2.trace.limit = 40
-    settings2.trace.delay = 30
-    settings2.trace.protocol = Protocol.ICMP
-    # settings2.page_load.target="https://www.wikipedia.org"  # target can't be updated after test has been created
-    settings2.page_load.timeout = 8000
-    settings2.page_load.headers = {"x-auth-token": "0FS230FJXGJK4234"}
-    settings2.page_load.ignore_tls_errors = False
-    settings2.page_load.css_selectors = {}
+    update_settings = deepcopy(initial_settings)
+    update_settings.family = IPFamily.V6
+    update_settings.period = 120
+    update_settings.agent_ids = [agents[1]]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    update_settings.tasks = [TaskType.PING, TaskType.TRACE_ROUTE, TaskType.PAGE_LOAD]
+    update_settings.ping.timeout = 4000
+    update_settings.ping.count = 6
+    update_settings.ping.delay = 300
+    update_settings.trace.timeout = 22750
+    update_settings.trace.count = 4
+    update_settings.trace.limit = 40
+    update_settings.trace.delay = 30
+    update_settings.trace.protocol = Protocol.ICMP
+    # update_settings.page_load.target="https://www.wikipedia.org"  # target can't be updated after test has been created
+    update_settings.page_load.timeout = 8000
+    update_settings.page_load.headers = {"x-auth-token": "0FS230FJXGJK4234"}
+    update_settings.page_load.ignore_tls_errors = False
+    update_settings.page_load.css_selectors = {}
 
-    try:
-        # create
-        test = PageLoadTest("e2e-pageload-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, PageLoadTest)
-        assert created_test.name == "e2e-pageload-test"
-        assert created_test.type == TestType.PAGE_LOAD
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
+    test = PageLoadTest(make_e2e_test_name(TestType.PAGE_LOAD), TestStatus.ACTIVE, initial_settings)
 
-        # read
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, PageLoadTest)
-        assert received_test.name == "e2e-pageload-test"
-        assert received_test.type == TestType.PAGE_LOAD
-        assert received_test.status == TestStatus.ACTIVE
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-pageload-test-updated"
-        created_test.settings = settings2
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, PageLoadTest)
-        assert updated_test.name == "e2e-pageload-test-updated"
-        assert updated_test.type == TestType.PAGE_LOAD
-        assert updated_test.status == TestStatus.ACTIVE
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_url.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_url.py
@@ -7,17 +7,25 @@ from kentik_api.synthetics.synth_tests.base import PingTask, TraceTask
 from kentik_api.synthetics.synth_tests.url import UrlTestSettings, URLTestSpecific
 from kentik_api.synthetics.types import IPFamily, Protocol, TaskType, TestStatus, TestType
 
-from .utils import HEALTH1, HEALTH2, client, credentials_missing_str, credentials_present, pick_agent_ids
+from .utils import (
+    INITIAL_HEALTH_SETTINGS,
+    UPDATE_HEALTH_SETTINGS,
+    credentials_missing_str,
+    credentials_present,
+    execute_test_crud_steps,
+    make_e2e_test_name,
+    pick_agent_ids,
+)
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
 def test_url_crud() -> None:
     agents = pick_agent_ids(count=2)
-    settings1 = UrlTestSettings(
+    initial_settings = UrlTestSettings(
         family=IPFamily.V4,
         period=60,
         agent_ids=[agents[0]],
-        health_settings=HEALTH1,
+        health_settings=INITIAL_HEALTH_SETTINGS,
         tasks=[TaskType.PING, TaskType.TRACE_ROUTE, TaskType.HTTP],
         ping=PingTask(timeout=3000, count=5, delay=200, protocol=Protocol.ICMP),
         trace=TraceTask(timeout=22500, count=3, limit=30, delay=20, protocol=Protocol.UDP, port=3343),
@@ -30,54 +38,27 @@ def test_url_crud() -> None:
             ignore_tls_errors=False,
         ),
     )
-    settings2 = deepcopy(settings1)
-    settings2.family = IPFamily.V6
-    settings2.period = 120
-    settings2.agent_ids = [agents[1]]
-    settings2.health_settings = HEALTH2
-    settings2.tasks = [TaskType.PING, TaskType.TRACE_ROUTE]
-    settings2.ping.timeout = 4000
-    settings2.ping.count = 6
-    settings2.ping.delay = 300
-    settings2.trace.timeout = 22750
-    settings2.trace.count = 4
-    settings2.trace.limit = 40
-    settings2.trace.delay = 30
-    settings2.trace.protocol = Protocol.ICMP
-    # settings2.url.target="https://www.wikipedia.org"  # target can't be updated after a test has been created
-    settings2.url.timeout = 8000
-    # settings2.url.http_method = "HEAD"  # Method can't be updated after a test has been created
-    settings2.url.headers = {"api-key": "KLAJ34AJFDHLAK653LXL"}
-    settings2.url.body = ""
-    settings2.url.ignore_tls_errors = True
+    update_settings = deepcopy(initial_settings)
+    update_settings.family = IPFamily.V6
+    update_settings.period = 120
+    update_settings.agent_ids = [agents[1]]
+    update_settings.health_settings = UPDATE_HEALTH_SETTINGS
+    update_settings.tasks = [TaskType.PING, TaskType.TRACE_ROUTE]
+    update_settings.ping.timeout = 4000
+    update_settings.ping.count = 6
+    update_settings.ping.delay = 300
+    update_settings.trace.timeout = 22750
+    update_settings.trace.count = 4
+    update_settings.trace.limit = 40
+    update_settings.trace.delay = 30
+    update_settings.trace.protocol = Protocol.ICMP
+    # update_settings.url.target="https://www.wikipedia.org"  # target can't be updated after a test has been created
+    update_settings.url.timeout = 8000
+    # update_settings.url.http_method = "HEAD"  # Method can't be updated after a test has been created
+    update_settings.url.headers = {"api-key": "KLAJ34AJFDHLAK653LXL"}
+    update_settings.url.body = ""
+    update_settings.url.ignore_tls_errors = True
 
-    try:
-        # create
-        test = UrlTest("e2e-url-test", TestStatus.ACTIVE, settings1)
-        created_test = client().synthetics.create_test(test)
-        assert isinstance(created_test, UrlTest)
-        assert created_test.name == "e2e-url-test"
-        assert created_test.type == TestType.URL
-        assert created_test.status == TestStatus.ACTIVE
-        assert created_test.settings == settings1
+    test = UrlTest(make_e2e_test_name(TestType.URL), TestStatus.ACTIVE, initial_settings)
 
-        # read
-        received_test = client().synthetics.get_test(created_test.id)
-        assert isinstance(received_test, UrlTest)
-        assert received_test.name == "e2e-url-test"
-        assert received_test.type == TestType.URL
-        assert received_test.status == TestStatus.ACTIVE
-        assert received_test.settings == settings1
-
-        # update
-        created_test.name = "e2e-url-test-updated"
-        created_test.settings = settings2
-        updated_test = client().synthetics.update_test(created_test)
-        assert isinstance(updated_test, UrlTest)
-        assert updated_test.name == "e2e-url-test-updated"
-        assert updated_test.type == TestType.URL
-        assert updated_test.status == TestStatus.ACTIVE
-        assert updated_test.settings == settings2
-    finally:
-        # delete (even if assertion failed)
-        client().synthetics.delete_test(created_test.id)
+    execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/utils.py
+++ b/kentik_api_library/tests/e2e/synthetics/utils.py
@@ -120,7 +120,7 @@ def execute_test_crud_steps(
     pause_after_creation: bool = False,
     pass_edate_in_update: bool = False,
 ) -> None:
-    test_id = 0
+    test_id = ID()
     try:
         # create
         created_test = client().synthetics.create_test(test)

--- a/kentik_api_library/tests/e2e/synthetics/utils.py
+++ b/kentik_api_library/tests/e2e/synthetics/utils.py
@@ -1,14 +1,23 @@
 import os
+from copy import deepcopy
+from datetime import timezone
 from typing import List
+from urllib.parse import urlparse
 
 from kentik_api import KentikAPI
 from kentik_api.public.types import ID
 from kentik_api.synthetics.agent import AgentImplementType
-from kentik_api.synthetics.synth_tests.base import ActivationSettings, HealthSettings
-from kentik_api.synthetics.types import IPFamily
-from kentik_api.utils import get_credentials
+from kentik_api.synthetics.synth_tests.base import (
+    ActivationSettings,
+    DateTime,
+    HealthSettings,
+    SynTest,
+    SynTestSettings,
+)
+from kentik_api.synthetics.types import IPFamily, TestStatus, TestType
+from kentik_api.utils import get_credentials, get_url
 
-HEALTH1 = HealthSettings(
+INITIAL_HEALTH_SETTINGS = HealthSettings(
     latency_critical=90,
     latency_warning=60,
     latency_critical_stddev=9,
@@ -29,7 +38,7 @@ HEALTH1 = HealthSettings(
     activation=ActivationSettings(grace_period="1", time_unit="m", time_window="5", times="3"),
 )
 
-HEALTH2 = HealthSettings(
+UPDATE_HEALTH_SETTINGS = HealthSettings(
     latency_critical=180,
     latency_warning=120,
     latency_critical_stddev=18,
@@ -50,15 +59,27 @@ HEALTH2 = HealthSettings(
     activation=ActivationSettings(grace_period="2", time_unit="h", time_window="1", times="4"),
 )
 
-credentials_missing_str = "KTAPI_AUTH_EMAIL and KTAPI_AUTH_TOKEN env variables are required to run the test"
-credentials_present = "KTAPI_AUTH_EMAIL" in os.environ and "KTAPI_AUTH_TOKEN" in os.environ
+required_env_variables = ["KTAPI_AUTH_EMAIL", "KTAPI_AUTH_TOKEN"]
+credentials_missing_str = f"{','.join(required_env_variables)} env variables are required to run the test"
+credentials_present = all(v in os.environ for v in required_env_variables)
+
+
+def make_e2e_test_name(test_type: TestType) -> str:
+    return f"e2e-{test_type.value}-test"
 
 
 def client() -> KentikAPI:
     """Get KentikAPI client"""
 
     email, token = get_credentials()
-    return KentikAPI(email, token)
+    url = get_url()
+    if url:
+        api_host = urlparse(url).netloc
+        if not api_host:
+            api_host = urlparse(url).path
+    else:
+        api_host = None
+    return KentikAPI(email, token, api_host=api_host)
 
 
 def pick_agent_ids(count: int = 1, page_load_support: bool = False) -> List[ID]:
@@ -83,3 +104,61 @@ def pick_agent_ids(count: int = 1, page_load_support: bool = False) -> List[ID]:
     ids = [a.id for a in requested_agents]
     print("### Selected Agent IDs:", ids)
     return ids
+
+
+def normalize_activation_settings(s: SynTestSettings) -> SynTestSettings:
+    out = deepcopy(s)
+    if out.health_settings.activation.time_unit == "h":
+        out.health_settings.activation.time_window = str(int(out.health_settings.activation.time_window) * 60)
+        out.health_settings.activation.time_unit = "m"
+    return out
+
+
+def execute_test_crud_steps(
+    test: SynTest,
+    update_settings: SynTestSettings,
+    pause_after_creation: bool = False,
+    pass_edate_in_update: bool = False,
+) -> None:
+    test_id = 0
+    try:
+        # create
+        created_test = client().synthetics.create_test(test)
+        test_id = created_test.id
+        print(f"created  id: {test_id} edate: {created_test.edate.isoformat()}")
+        assert isinstance(created_test, type(test))
+        assert created_test.name == test.name
+        assert created_test.type == test.type
+        assert created_test.status == TestStatus.ACTIVE
+        assert created_test.settings == normalize_activation_settings(test.settings)
+
+        # set status
+        if pause_after_creation:
+            client().synthetics.set_test_status(created_test.id, TestStatus.PAUSED)
+
+        # read
+        received_test = client().synthetics.get_test(created_test.id)
+        assert isinstance(received_test, type(test))
+        assert received_test.name == created_test.name
+        assert received_test.type == created_test.type
+        assert received_test.status == TestStatus.PAUSED if pause_after_creation else TestStatus.ACTIVE
+        assert received_test.settings == normalize_activation_settings(test.settings)
+
+        # update
+        received_test.name = f"{test.name}-updated"
+        received_test.status = TestStatus.ACTIVE
+        received_test.settings = update_settings
+        if not pass_edate_in_update:
+            received_test.edate = DateTime.fromtimestamp(0, tz=timezone.utc)
+
+        print(f"received id: {received_test.id} edate: {received_test.edate.isoformat()}")
+        updated_test = client().synthetics.update_test(received_test)
+        assert isinstance(updated_test, type(test))
+        assert updated_test.name == received_test.name
+        assert updated_test.type == received_test.type
+        assert updated_test.status == received_test.status
+        assert updated_test.settings == normalize_activation_settings(received_test.settings)
+    finally:
+        # delete the created test, if any, even if an assertion failed or other problem has occurred
+        if test_id:
+            client().synthetics.delete_test(test_id)


### PR DESCRIPTION
- Preserve nanosecond resolution of timestamps
- Add validation of `settings.health_settings.activation` attributes
- Add validation of test period
- Fix `SynTest.targets` method
- Set default `api-host` of a null one is explicitly passed to KentikAPI
- gitingore (again) JetBrains config directory (.idea)
- remove unused imports here and there, improve formatting