### PR TITLE
Enable support for `labels` on synthetic agents and tests

### DIFF
--- a/kentik_api_library/kentik_api/synthetics/agent.py
+++ b/kentik_api_library/kentik_api/synthetics/agent.py
@@ -59,6 +59,7 @@ class Agent(_ConfigElement):
     local_ip: IP = IP()
     cloud_region: str = ""
     cloud_provider: str = ""
+    labels: List[str] = field(default_factory=list)
 
     @property
     def os(self) -> str:
@@ -83,3 +84,11 @@ class Agent(_ConfigElement):
     @property
     def last_authed(self) -> DateTime:
         return self._last_authed
+
+    @property
+    def is_private(self) -> bool:
+        return self.type == AgentOwnershipType.PRIVATE
+
+    @property
+    def is_app_agent(self) -> bool:
+        return self.agent_impl == AgentImplementType.NODE

--- a/kentik_api_library/kentik_api/synthetics/synth_client.py
+++ b/kentik_api_library/kentik_api/synthetics/synth_client.py
@@ -34,9 +34,9 @@ class KentikSynthClient:
     def __init__(self, connector: APISyntheticsConnectorProtocol):
         self._connector = connector
 
-    def get_all_agents(self) -> List[Agent]:
+    def get_all_agents(self, private_only=False) -> List[Agent]:
         pb_agents = self._connector.get_all_agents()
-        return [Agent.from_pb(agent) for agent in pb_agents]
+        return [Agent.from_pb(agent) for agent in pb_agents if not private_only or agent.type == "private"]
 
     def get_agent(self, agent_id: ID) -> Agent:
         pb_agent = self._connector.get_agent(str(agent_id))

--- a/kentik_api_library/kentik_api/synthetics/synth_tests/base.py
+++ b/kentik_api_library/kentik_api/synthetics/synth_tests/base.py
@@ -96,7 +96,9 @@ class _ConfigElement:
 
     @classmethod
     def from_pb(cls: Type[_ConfigElementT], obj: Any) -> _ConfigElementT:
-        """from_pb can be overridden in a child class to tweak deserialization behavior, and still call _from_protobuf"""
+        """
+        from_pb can be overridden in a child class to tweak deserialization behavior, and still call _from_protobuf
+        """
 
         return cls._from_protobuf(obj)
 
@@ -283,7 +285,7 @@ class SynTest(_ConfigElement):
     type: TestType = field(init=False, default=TestType.NONE)
     status: TestStatus = field(default=TestStatus.ACTIVE)
     settings: SynTestSettings = field(default_factory=SynTestSettings)
-    # labels: List[str] = field(default_factory=list) # not supported yet
+    labels: List[str] = field(default_factory=list)
     edate: DateTime = field(default=DateTime.fromtimestamp(0, tz=timezone.utc), init=False)  # yes, edate is read-write
 
     # read-only

--- a/kentik_api_library/tests/e2e/README.md
+++ b/kentik_api_library/tests/e2e/README.md
@@ -1,5 +1,5 @@
 # e2e tests
 
 E2E tests connect to production Kentik server and require valid credentials passed
-in KTAPI_AUTH_EMAIL and KTAPI_AUTH_TOKEN env variables. Target API end-point may be set
+in KTAPI_AUTH_EMAIL and KTAPI_AUTH_TOKEN env variables. Target API endpoint may be set
 via the KTAPI_URL environment variable (default: "https://grpc.api.kentik.com")

--- a/kentik_api_library/tests/e2e/README.md
+++ b/kentik_api_library/tests/e2e/README.md
@@ -1,5 +1,20 @@
-# e2e tests
+# End-to-End (e2e) tests 
 
-E2E tests connect to production Kentik server and require valid credentials passed
-in KTAPI_AUTH_EMAIL and KTAPI_AUTH_TOKEN env variables. Target API endpoint may be set
-via the KTAPI_URL environment variable (default: "https://grpc.api.kentik.com")
+The e2e test suite verifies:
+- CRUD operations for all supported test types
+- listing of all tests
+- listing of all agents
+
+It interacts with production Kentik API and requires account with sufficient synthetic test
+credits. User credentials myst be passed in KTAPI_AUTH_EMAIL and KTAPI_AUTH_TOKEN env variables.
+Target API endpoint may be set  via the KTAPI_URL environment variable (default: "https://grpc.api.kentik.com")
+
+Since labels used for labeling synthetic tests and agents must exist in the target
+environment and there is currently no way to create them programmatically,
+set of labels can be provided using the `test_labels` argument to the `pytest` command.
+The value of the argument is comma separated list of strings. Default is no labels.
+
+Example test suite invocation:
+```
+python3 -m pytest --test_labels "label1,label2" tests/e2e/synthetics/
+```

--- a/kentik_api_library/tests/e2e/README.md
+++ b/kentik_api_library/tests/e2e/README.md
@@ -1,3 +1,5 @@
 # e2e tests
 
-E2E tests connect to production Kentik server and require valid credentials passed as KTAPI_AUTH_EMAIL and KTAPI_AUTH_TOKEN env variables.
+E2E tests connect to production Kentik server and require valid credentials passed
+in KTAPI_AUTH_EMAIL and KTAPI_AUTH_TOKEN env variables. Target API end-point may be set
+via the KTAPI_URL environment variable (default: "https://grpc.api.kentik.com")

--- a/kentik_api_library/tests/e2e/README.md
+++ b/kentik_api_library/tests/e2e/README.md
@@ -1,4 +1,4 @@
-# End-to-End (e2e) tests 
+# End-to-End (e2e) tests
 
 The e2e test suite verifies:
 - CRUD operations for all supported test types
@@ -15,6 +15,6 @@ set of labels can be provided using the `test_labels` argument to the `pytest` c
 The value of the argument is comma separated list of strings. Default is no labels.
 
 Example test suite invocation:
-```
+```shell
 python3 -m pytest --test_labels "label1,label2" tests/e2e/synthetics/
 ```

--- a/kentik_api_library/tests/e2e/synthetics/conftest.py
+++ b/kentik_api_library/tests/e2e/synthetics/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--test_labels", action="store", default="")
+
+
+@pytest.fixture(scope="session")
+def test_labels(pytestconfig):
+    labels = pytestconfig.getoption("test_labels")
+    if labels:
+        return labels.split(",")
+    else:
+        return []

--- a/kentik_api_library/tests/e2e/synthetics/test_agent.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_agent.py
@@ -19,7 +19,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_agent_test_crud() -> None:
+def test_agent_test_crud(test_labels) -> None:
     agents = pick_agent_ids(count=4)
     initial_settings = AgentTestSettings(
         family=IPFamily.V4,
@@ -45,6 +45,8 @@ def test_agent_test_crud() -> None:
     update_settings.trace.protocol = Protocol.ICMP
     update_settings.agent.target = agents[3]
     update_settings.agent.use_local_ip = True
+
     test = AgentTest(make_e2e_test_name(TestType.AGENT), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings, pause_after_creation=True)

--- a/kentik_api_library/tests/e2e/synthetics/test_dns.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_dns.py
@@ -18,7 +18,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_dns_crud() -> None:
+def test_dns_crud(test_labels) -> None:
     agents = pick_agent_ids(count=2)
     initial_settings = DNSTestSettings(
         family=IPFamily.V4,
@@ -43,5 +43,6 @@ def test_dns_crud() -> None:
     update_settings.dns.port = 63
 
     test = DNSTest(make_e2e_test_name(TestType.DNS), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_dns_grid.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_dns_grid.py
@@ -18,7 +18,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_dns_grid_crud() -> None:
+def test_dns_grid_crud(test_labels) -> None:
     agents = pick_agent_ids(count=2)
     initial_settings = DNSGridTestSettings(
         family=IPFamily.V4,
@@ -43,5 +43,6 @@ def test_dns_grid_crud() -> None:
     update_settings.dns_grid.port = 63
 
     test = DNSGridTest(make_e2e_test_name(TestType.DNS_GRID), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_flow.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_flow.py
@@ -19,7 +19,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_flow_crud() -> None:
+def test_flow_crud(test_labels) -> None:
     agents = pick_agent_ids(count=2)
     initial_settings = FlowTestSettings(
         family=IPFamily.V4,
@@ -60,5 +60,6 @@ def test_flow_crud() -> None:
     update_settings.flow.direction = DirectionType.SRC
 
     test = FlowTest(make_e2e_test_name(TestType.FLOW), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_hostname.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_hostname.py
@@ -19,7 +19,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_hostname_crud() -> None:
+def test_hostname_crud(test_labels) -> None:
     agents = pick_agent_ids(count=2)
     initial_settings = HostnameTestSettings(
         family=IPFamily.V4,
@@ -46,5 +46,6 @@ def test_hostname_crud() -> None:
     # update_settings.hostname.target="www.wikipedia.org"  # target can't be updated after test's been created
 
     test = HostnameTest(make_e2e_test_name(TestType.HOSTNAME), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_ip.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_ip.py
@@ -20,7 +20,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_ip_crud() -> None:
+def test_ip_crud(test_labels) -> None:
     agents = pick_agent_ids(count=2)
     initial_settings = IPTestSettings(
         family=IPFamily.V4,
@@ -47,5 +47,6 @@ def test_ip_crud() -> None:
     # update_settings.ip.targets = [IP("55.161.222.85"), IP("35.205.242.146")]  # can't update after creation
 
     test = IPTest(make_e2e_test_name(TestType.IP), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_network_grid.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_network_grid.py
@@ -20,7 +20,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_network_grid_crud() -> None:
+def test_network_grid_crud(test_labels) -> None:
     agents = pick_agent_ids(count=2)
     initial_settings = GridTestSettings(
         family=IPFamily.V4,
@@ -47,5 +47,6 @@ def test_network_grid_crud() -> None:
     update_settings.network_grid.targets = [IP("77.126.243.32"), IP("44.211.231.198")]
 
     test = NetworkGridTest(make_e2e_test_name(TestType.NETWORK_GRID), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_network_mesh.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_network_mesh.py
@@ -19,7 +19,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_network_mesh_crud() -> None:
+def test_network_mesh_crud(test_labels) -> None:
     agents = pick_agent_ids(count=4)
     initial_settings = NetworkMeshTestSettings(
         family=IPFamily.V4,
@@ -46,5 +46,6 @@ def test_network_mesh_crud() -> None:
     # update_settings.network_mesh.use_local_ip=False  # can't be updated after a test's been created
 
     test = NetworkMeshTest(make_e2e_test_name(TestType.NETWORK_MESH), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_page_load.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_page_load.py
@@ -19,7 +19,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_page_load_crud() -> None:
+def test_page_load_crud(test_labels) -> None:
     agents = pick_agent_ids(count=2, page_load_support=True)
     initial_settings = PageLoadTestSettings(
         family=IPFamily.V4,
@@ -58,5 +58,6 @@ def test_page_load_crud() -> None:
     update_settings.page_load.css_selectors = {}
 
     test = PageLoadTest(make_e2e_test_name(TestType.PAGE_LOAD), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/test_url.py
+++ b/kentik_api_library/tests/e2e/synthetics/test_url.py
@@ -19,7 +19,7 @@ from .utils import (
 
 
 @pytest.mark.skipif(not credentials_present, reason=credentials_missing_str)
-def test_url_crud() -> None:
+def test_url_crud(test_labels) -> None:
     agents = pick_agent_ids(count=2)
     initial_settings = UrlTestSettings(
         family=IPFamily.V4,
@@ -60,5 +60,6 @@ def test_url_crud() -> None:
     update_settings.url.ignore_tls_errors = True
 
     test = UrlTest(make_e2e_test_name(TestType.URL), TestStatus.ACTIVE, initial_settings)
+    test.labels = test_labels
 
     execute_test_crud_steps(test, update_settings=update_settings)

--- a/kentik_api_library/tests/e2e/synthetics/utils.py
+++ b/kentik_api_library/tests/e2e/synthetics/utils.py
@@ -1,7 +1,7 @@
 import os
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlparse
 
 from kentik_api import KentikAPI
@@ -120,9 +120,13 @@ def execute_test_crud_steps(
     update_settings: SynTestSettings,
     pause_after_creation: bool = False,
     pass_edate_in_update: bool = False,
+    labels: Optional[List[str]] = None,
 ) -> None:
     test_id = ID()
     try:
+        # set test labels if any
+        if labels:
+            test.labels = labels
         # create
         created_test = client().synthetics.create_test(test)
         test_id = created_test.id
@@ -132,6 +136,8 @@ def execute_test_crud_steps(
         assert created_test.type == test.type
         assert created_test.status == TestStatus.ACTIVE
         assert created_test.settings == normalize_activation_settings(test.settings)
+        if labels:
+            assert created_test.labels == test.labels
 
         # set status
         if pause_after_creation:

--- a/kentik_api_library/tests/e2e/synthetics/utils.py
+++ b/kentik_api_library/tests/e2e/synthetics/utils.py
@@ -1,6 +1,6 @@
 import os
 from copy import deepcopy
-from datetime import timezone
+from datetime import datetime, timezone
 from typing import List
 from urllib.parse import urlparse
 
@@ -65,7 +65,8 @@ credentials_present = all(v in os.environ for v in required_env_variables)
 
 
 def make_e2e_test_name(test_type: TestType) -> str:
-    return f"e2e-{test_type.value}-test"
+    now = datetime.now(tz=timezone.utc)
+    return f"pysdk_e2e-{now.isoformat()}-{test_type.value}"
 
 
 def client() -> KentikAPI:


### PR DESCRIPTION
`SynTest` and `Agent` classes now have `labels` properties.

Also includes:
- more unique names for e2e synthetic tests
- optional argument for `synthetics.get_all_agents` allowing to filter only private agents
- utility methods for `Agent` class allowing to easily identify private and app (a.k.a. node) agents