### PR TITLE
Fix for handling the `not_` attribute in FilterGroups 

### DIFF
--- a/kentik_api_library/examples/saved_filters_example.py
+++ b/kentik_api_library/examples/saved_filters_example.py
@@ -27,7 +27,7 @@ def run_crud() -> None:
 
     print("### CREATE")
     filter_ = Filter(filterField="dst_as", filterValue="81", operator="=")
-    filter_groups = [FilterGroups(connector="All", not_=False, filters=[filter_])]
+    filter_groups = [FilterGroups(connector="All", is_negation=False, filters=[filter_])]
     filters = Filters(connector="All", filterGroups=filter_groups)
     to_create = SavedFilter(
         filter_name="test_filter1",

--- a/kentik_api_library/examples/saved_filters_example.py
+++ b/kentik_api_library/examples/saved_filters_example.py
@@ -27,7 +27,7 @@ def run_crud() -> None:
 
     print("### CREATE")
     filter_ = Filter(filterField="dst_as", filterValue="81", operator="=")
-    filter_groups = [FilterGroups(connector="All", is_negation=False, filters=[filter_])]
+    filter_groups = [FilterGroups(connector="All", filters=[filter_])]
     filters = Filters(connector="All", filterGroups=filter_groups)
     to_create = SavedFilter(
         filter_name="test_filter1",

--- a/kentik_api_library/kentik_api/public/saved_filter.py
+++ b/kentik_api_library/kentik_api/public/saved_filter.py
@@ -1,10 +1,9 @@
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from kentik_api.internal.dataclass import mandatory_dataclass_attributes
 from kentik_api.public.errors import IncompleteObjectError
 from kentik_api.public.types import ID
-
 
 FilterGroupsType = TypeVar("FilterGroupsType", bound="FilterGroups")
 FiltersType = TypeVar("FiltersType", bound="Filters")

--- a/kentik_api_library/kentik_api/requests_payload/conversions.py
+++ b/kentik_api_library/kentik_api/requests_payload/conversions.py
@@ -9,15 +9,19 @@ from kentik_api.public.errors import DataFormatError, DeserializationError
 
 def as_dict(obj: Any) -> Dict[str, Any]:
     """Convert obj to dict, removing all keys with None values"""
-
     if not (hasattr(obj, "__dict__") or isinstance(obj, dict)):
         raise DataFormatError("Object as dict", f"Input should be either class or dict , got: {type(obj)}")
 
-    if hasattr(obj, "__dict__"):
-        obj = obj.__dict__
+    if hasattr(obj, "to_dict"):
+        return obj.to_dict()
 
-    result = dict()
-    for k, v in obj.items():
+    if hasattr(obj, "__dict__"):
+        d = obj.__dict__
+    else:
+        d = obj
+
+    result: Dict[str, Any] = dict()
+    for k, v in d.items():
         if v is None:
             continue
         if isinstance(v, Enum):

--- a/kentik_api_library/kentik_api/requests_payload/saved_filters_payload.py
+++ b/kentik_api_library/kentik_api/requests_payload/saved_filters_payload.py
@@ -30,7 +30,7 @@ class SavedFilterPayload:
                     }
                     for j in i.filters
                 ],
-                "not": i.not_,
+                "not": i.is_negation,
             }
             for i in filter_groups
         ]
@@ -92,10 +92,11 @@ class GetResponse:
             filters=filters,
             id=convert_or_none(dic.get("id"), ID),
             metric=dic.get("metric"),
-            not_=convert(dic["not"], bool),
+            is_negation=convert(dic["not"], bool),
         )
 
-    def _to_filter(self, dic) -> Filter:
+    @staticmethod
+    def _to_filter(dic) -> Filter:
         dic["id"] = convert_or_none(dic.get("id"), ID)
         return from_dict(Filter, dic)
 
@@ -157,5 +158,5 @@ def validate(saved_filter: SavedFilter, operation: str):
             raise IncompleteObjectError(operation, class_name, "connector is required")
         if not all(i.connector is not None for i in saved_filter.filters.filterGroups):
             raise IncompleteObjectError(operation, class_name, "filterGroups connector is required")
-        if not all(i.not_ is not None for i in saved_filter.filters.filterGroups):
+        if not all(i.is_negation is not None for i in saved_filter.filters.filterGroups):
             raise IncompleteObjectError(operation, class_name, "not_ is required")

--- a/kentik_api_library/kentik_api/requests_payload/saved_filters_payload.py
+++ b/kentik_api_library/kentik_api/requests_payload/saved_filters_payload.py
@@ -30,7 +30,7 @@ class SavedFilterPayload:
                     }
                     for j in i.filters
                 ],
-                "not": i.is_negation,
+                "not": i.not_,
             }
             for i in filter_groups
         ]
@@ -92,7 +92,7 @@ class GetResponse:
             filters=filters,
             id=convert_or_none(dic.get("id"), ID),
             metric=dic.get("metric"),
-            is_negation=convert(dic["not"], bool),
+            not_=convert(dic["not"], bool),
         )
 
     @staticmethod
@@ -158,5 +158,5 @@ def validate(saved_filter: SavedFilter, operation: str):
             raise IncompleteObjectError(operation, class_name, "connector is required")
         if not all(i.connector is not None for i in saved_filter.filters.filterGroups):
             raise IncompleteObjectError(operation, class_name, "filterGroups connector is required")
-        if not all(i.is_negation is not None for i in saved_filter.filters.filterGroups):
+        if not all(i.not_ is not None for i in saved_filter.filters.filterGroups):
             raise IncompleteObjectError(operation, class_name, "not_ is required")

--- a/kentik_api_library/tests/unit/api_resources/test_queries.py
+++ b/kentik_api_library/tests/unit/api_resources/test_queries.py
@@ -213,7 +213,7 @@ def test_query_chart_success() -> None:
     )
     agg3 = Aggregate(name="max_bits_per_sec", column="f_sum_both_bytes", fn=AggregateFunctionType.max)
     filter_ = Filter(filterField="dst_as", operator="=", filterValue="")
-    filter_group = FilterGroups(connector="All", not_=False, filters=[filter_])
+    filter_group = FilterGroups(connector="All", is_negation=False, filters=[filter_])
     filters = Filters(connector="", filterGroups=[filter_group])
     query = Query(
         viz_type=ChartViewType.stackedArea,

--- a/kentik_api_library/tests/unit/api_resources/test_queries.py
+++ b/kentik_api_library/tests/unit/api_resources/test_queries.py
@@ -213,7 +213,7 @@ def test_query_chart_success() -> None:
     )
     agg3 = Aggregate(name="max_bits_per_sec", column="f_sum_both_bytes", fn=AggregateFunctionType.max)
     filter_ = Filter(filterField="dst_as", operator="=", filterValue="")
-    filter_group = FilterGroups(connector="All", is_negation=False, filters=[filter_])
+    filter_group = FilterGroups(connector="All", not_=False, filters=[filter_])
     filters = Filters(connector="", filterGroups=[filter_group])
     query = Query(
         viz_type=ChartViewType.stackedArea,

--- a/kentik_api_library/tests/unit/api_resources/test_saved_filters.py
+++ b/kentik_api_library/tests/unit/api_resources/test_saved_filters.py
@@ -38,7 +38,7 @@ def test_create_saved_filter_success() -> None:
 
     # when
     filter_ = Filter(filterField="dst_as", filterValue="81", operator="=")
-    filter_groups = [FilterGroups(connector="All", is_negation=False, filters=[filter_])]
+    filter_groups = [FilterGroups(connector="All", not_=False, filters=[filter_])]
     filters = Filters(connector="All", filterGroups=filter_groups)
     to_create = SavedFilter(
         filter_name="test_filter1",
@@ -68,7 +68,7 @@ def test_create_saved_filter_success() -> None:
     assert created.filters is not None
     assert created.filters.connector == "All"
     assert created.filters.filterGroups[0].connector == "All"
-    assert created.filters.filterGroups[0].is_negation is False
+    assert created.filters.filterGroups[0].not_ is False
     assert created.filters.filterGroups[0].filters[0].filterField == "dst_as"
     assert created.filters.filterGroups[0].filters[0].filterValue == "81"
     assert created.filters.filterGroups[0].filters[0].operator == "="
@@ -121,7 +121,7 @@ def test_get_saved_filter_success() -> None:
     assert saved_filter.filters is not None
     assert saved_filter.filters.connector == "All"
     assert saved_filter.filters.filterGroups[0].connector == "All"
-    assert saved_filter.filters.filterGroups[0].is_negation is False
+    assert saved_filter.filters.filterGroups[0].not_ is False
     assert saved_filter.filters.filterGroups[0].filters[0].filterField == "dst_as"
     assert saved_filter.filters.filterGroups[0].filters[0].filterValue == "81"
     assert saved_filter.filters.filterGroups[0].filters[0].operator == "="
@@ -158,7 +158,10 @@ def test_update_saved_filter_success() -> None:
     # when
     filter_id = ID(8153)
     filter_ = Filter(filterField="dst_as", filterValue="81", operator="=")
-    filter_groups = [FilterGroups(connector="All", is_negation=False, filters=[filter_])]
+    filter_groups = [FilterGroups(connector="All", filters=[filter_])]
+    # test correct initialization of the FilterGroups.not_ attribute
+    assert filter_groups[0].not_ is False
+
     filters = Filters(connector="All", filterGroups=filter_groups)
     to_update = SavedFilter(
         filter_name="test_filter1",

--- a/kentik_api_library/tests/unit/api_resources/test_saved_filters.py
+++ b/kentik_api_library/tests/unit/api_resources/test_saved_filters.py
@@ -38,7 +38,7 @@ def test_create_saved_filter_success() -> None:
 
     # when
     filter_ = Filter(filterField="dst_as", filterValue="81", operator="=")
-    filter_groups = [FilterGroups(connector="All", not_=False, filters=[filter_])]
+    filter_groups = [FilterGroups(connector="All", is_negation=False, filters=[filter_])]
     filters = Filters(connector="All", filterGroups=filter_groups)
     to_create = SavedFilter(
         filter_name="test_filter1",
@@ -68,7 +68,7 @@ def test_create_saved_filter_success() -> None:
     assert created.filters is not None
     assert created.filters.connector == "All"
     assert created.filters.filterGroups[0].connector == "All"
-    assert created.filters.filterGroups[0].not_ is False
+    assert created.filters.filterGroups[0].is_negation is False
     assert created.filters.filterGroups[0].filters[0].filterField == "dst_as"
     assert created.filters.filterGroups[0].filters[0].filterValue == "81"
     assert created.filters.filterGroups[0].filters[0].operator == "="
@@ -121,7 +121,7 @@ def test_get_saved_filter_success() -> None:
     assert saved_filter.filters is not None
     assert saved_filter.filters.connector == "All"
     assert saved_filter.filters.filterGroups[0].connector == "All"
-    assert saved_filter.filters.filterGroups[0].not_ is False
+    assert saved_filter.filters.filterGroups[0].is_negation is False
     assert saved_filter.filters.filterGroups[0].filters[0].filterField == "dst_as"
     assert saved_filter.filters.filterGroups[0].filters[0].filterValue == "81"
     assert saved_filter.filters.filterGroups[0].filters[0].operator == "="
@@ -158,7 +158,7 @@ def test_update_saved_filter_success() -> None:
     # when
     filter_id = ID(8153)
     filter_ = Filter(filterField="dst_as", filterValue="81", operator="=")
-    filter_groups = [FilterGroups(connector="All", not_=False, filters=[filter_])]
+    filter_groups = [FilterGroups(connector="All", is_negation=False, filters=[filter_])]
     filters = Filters(connector="All", filterGroups=filter_groups)
     to_update = SavedFilter(
         filter_name="test_filter1",


### PR DESCRIPTION
Customer has discovered that their application started failing after upgrade to SDK version 1.0.0. The failure manifested as failure to serialize request to JSON. The root cause was that the `not_` property of the `FilterGroups` object has not been properly initialized. This PR fixes this problem which required slight refactoring of serialization of `FilterGroups` objects.