### PR TITLE
Fix passing `None` as profile to `get_credentials`

### DIFF
--- a/kentik_api_library/kentik_api/utils/auth.py
+++ b/kentik_api_library/kentik_api/utils/auth.py
@@ -9,6 +9,8 @@ log = logging.getLogger("auth")
 
 @lru_cache
 def load_credential_profile(profile: str) -> Dict:
+    if not profile:
+        return {}
     home: str = os.environ.get("KTAPI_HOME", os.environ.get("HOME", "."))
     filename = os.environ.get("KTAPI_CFG_FILE", os.path.join(home, ".kentik", profile))
     try:


### PR DESCRIPTION
This supports corner case when only credentials in environment variables should be considered while using the `get_credentials` function.