### PR TITLE
Proto import path update.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ class GenerateGRPCStubs(Command):
         deps = [
             "protovendor/github.com/googleapis/googleapis",
             "protovendor/github.com/grpc-ecosystem/grpc-gateway",
-            "protovendor/github.com/protocolbuffers/src",
+            "protovendor/github.com/protocolbuffers/protobuf/src",
         ]
         # cleanup destination directory
         shutil.rmtree(dst_path, ignore_errors=True)  # ignore "No such file or directory"


### PR DESCRIPTION
The `protovendor/github.com/protocolbuffers/src` directory has been moved to `protovendor/github.com/protocolbuffers/protobuf/src` in order to make automatic updates of vendored proto files easier in the internal repo.